### PR TITLE
GitHub contributors

### DIFF
--- a/api/schema/resolvers/ProjectResolver.js
+++ b/api/schema/resolvers/ProjectResolver.js
@@ -371,8 +371,6 @@ module.exports = {
         syncProjectGithubContributors: async (root, { project_id }, { models }) => {
             const project = await models.Project.findByPk(project_id)
             const repo = split(project.github_url, '/')
-            console.log('repo');
-            console.log(repo);
             return dataSyncs.syncGithubRepoContributors({
                 repo: repo[repo.length - 1]
             })


### PR DESCRIPTION
Issue #205 

**Description:**

This pr contains the backend logic to be able to add into our contributors table in the db those contributors from a GitHub repo that belongs to a specified project.

**Breakdown:**

* Function `fetchRepoContributors` to fetch repo contributors from Github (implemented in `/api/handlers/github.js`)
* Function `fetchUserData` to fetch a GitHub user information given its username (implemented in `/api/handlers/github.js`). The reason why this is implemented is because `fetchRepoContributors` doesn't returns the name of the contributor, and this piece of data it's needed for adding a new contributor in the db
* Function `syncGithubRepoContributors` to add into our contributors table those contributors fetched from GitHub that are not already in our db, the function matches repeated contributors using the `github_id` attribute (implemented in `/api/dataSyncs.js`)
* mutation `syncProjectGithubContributors` added into the Project type since it's a mutation that requires a project id (Implemented in both `/api/schema/types/ProjectType.js` and `/api/schema/resolvers/ProjectResolver.js`
* Some general cleanup

**Important stuff to notice**

* Sometimes the GitHub contributor doesn't have a name so in this cases we use they GitHub username as the `name` attribute in the contributors table
* I had to change the name of the old function `fetchUserData`, used in the authentication process to get info of the contributor that was logging into the app, to `fetchAuthUserData`. The reasoning behind this is that I felt like `fetchUserData` was a good name for calling another GitHub API function. Using the atom editor find and replace tool I replaced all the appearance of the old  `fetchUserData` function to `fetchAuthUserData`. I also tested that I didn't break anything on this side of the app.
* Just to clarify a GitHub contributor it's not the same as a GitHub team member, so if we're expecting to get the team members using this implementation we will not get the expected data, a GitHub contributor could be a GitHub team member and a team member doesn't necessarily have to be a GitHub contributor. Also a contributor and a collaborator are not the same (https://github.com/CoolProp/CoolProp/wiki/Contributors-vs-Collaborators) 

**Reasoning**

The reason why I made this implementation is because for the `ProjectContributorsPage` we have to show the db contributors and also the ones that comes from the GitHub repo, so this mutation will be called  when the user goes to `http://localhost:6002/projects/X/contributors` 

**Proof of implementation**

https://www.loom.com/share/726435addd9842a6898e9fc2d830ab26

@otech47 

