### PR TITLE
Swipeable navigation in development stage

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import { ThemeProvider } from '@material-ui/core/styles'
 
 import theme from './styles/theme'
 
-import { API_ROOT } from './constants'
+import { API_ROOT, IS_PRODUCTION } from './constants'
 
 import AddClientPage from './pages/AddClientPage'
 import AddProjectPage from './pages/AddProjectPage'
@@ -19,15 +19,23 @@ import Authentication from './components/Authentication'
 import Navigation from './components/Navigation'
 import PrivateRoute from './components/PrivateRoute'
 import PublicRoute from './components/PublicRoute'
+import SwipeableNavigation from './components/SwipeableNavigation'
 
 class App extends React.Component {
 
     render() {
 
+        console.log('IS_PRODUCTION');
+        console.log(IS_PRODUCTION);
+
         return (
             <div className='App'>
                 <Authentication/>
-                <Navigation/>
+                {
+                    IS_PRODUCTION
+                        ? <Navigation/>
+                        : <SwipeableNavigation/>
+                }
                 <ThemeProvider theme={theme}>
                     <PrivateRoute
                         exact

--- a/src/components/SwipeableNavigation.js
+++ b/src/components/SwipeableNavigation.js
@@ -1,0 +1,84 @@
+import React, { useState } from 'react'
+import { useHistory } from 'react-router-dom'
+import {
+    Button,
+    Grid,
+    IconButton,
+    List,
+    ListItem,
+    ListItemText,
+    SwipeableDrawer,
+} from '@material-ui/core';
+import { makeStyles, useTheme } from '@material-ui/core/styles'
+import MenuIcon from '@material-ui/icons/Menu'
+
+import { IS_PRODUCTION, NAV_ITEMS } from '../constants'
+
+const useStyles = makeStyles({
+    list: {
+        width: 250,
+    }
+})
+
+const SwipeableNavigation = (props) => {
+    const history = useHistory()
+    const classes = useStyles()
+    const [opened, setOpened] = useState(false)
+
+    const toggleDrawer = (event, opened) => {
+        // Allow for tab presses without closing
+        // the drawer
+        if (
+            event &&
+            event.type === 'keydown' &&
+            event.key === 'Tab'
+        ) {
+            return;
+        }
+
+        setOpened(opened)
+    }
+
+    return (
+        <div className='SwipeableNavigation'>
+            <Grid container>
+                <Grid item xs={1}>
+                    <IconButton onClick={(e) => toggleDrawer(e, true)}>
+                        <MenuIcon/>
+                    </IconButton>
+                </Grid>
+            </Grid>
+
+            <SwipeableDrawer
+                anchor='left'
+                open={opened}
+                onClose={(e) => toggleDrawer(e, false)}
+                onOpen={(e) => toggleDrawer(e, true)}
+            >
+                <div
+                    className={classes.list}
+                    role='presentation'
+                    onClick={(e) => toggleDrawer(e, false)}
+                    onKeyDown={(e) => toggleDrawer(e, false)}
+                >
+                    <List>
+                        {NAV_ITEMS.map((item, index) => (
+                            <ListItem
+                                button
+                                key={`nli-${index}`}
+                                onClick={(e) => {
+                                    toggleDrawer(e, false)
+                                    history.push(item.route)
+                                }}
+                            >
+                                <ListItemText primary={item.text} />
+                            </ListItem>
+                        ))}
+                    </List>
+                </div>
+            </SwipeableDrawer>
+        </div>
+    )
+}
+
+export default SwipeableNavigation

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,7 +1,4 @@
-export const LOGO_URL = 'https://project-trinary.s3.amazonaws.com/images/Logo.png'
-
 export const API_ROOT = process.env.REACT_APP_API_URL
-
 export const CURRENCIES = [
     {
         name: 'USD'
@@ -14,5 +11,37 @@ export const CURRENCIES = [
     },
     {
         name: 'BTC'
+    }
+]
+export const IS_PRODUCTION = process.env.NODE_ENV == 'production' ? true : false
+export const LOGO_URL = 'https://project-trinary.s3.amazonaws.com/images/Logo.png'
+export const NAV_ITEMS = [
+    {
+        text: 'Home',
+        route: '/',
+    },
+    {
+        text: 'LoginPage',
+        route: '/login',
+    },
+    {
+        text: 'Clients List Page',
+        route: '/clients'
+    },
+    {
+        text: 'ClientDetailPage',
+        route: '/clients/1',
+    },
+    {
+        text: 'AddClientPage',
+        route: '/client/add',
+    },
+    {
+        text: 'ProjectDetailPage',
+        route: '/projects/1',
+    },
+    {
+        text: 'AddProjectPage',
+        route: '/project/add'
     }
 ]


### PR DESCRIPTION
### **Issue #216**


**Description:**

Feature suggested by @otech47 in a closed pr

> Only thing I would suggest here as a new issue is to go back and re-enable the swipeable navigation and refactor to use a process.env.NODE_ENV == 'production' check to hide it away. The reasoning is it could be useful as a development tool to be able to jump around different pages of the app.

**Breakdown:**

* `SwipeableNavigation` component that renders old swipeable navigation menu
* `IS_PRODUCTION` boolean constant tho know the stage where the app is running (local/production) (implemented in `src/constants/index.js`)
* Logic to render the `Navigation` or `SwipeableNavigation` component based on `IS_PRODUCTION` value (implemented in `src/app.js`)

**How to test this:**

1. Make `git pull` from develop branch
2. `git checkout sr/issue-216/swipeable-navigation`
3. `npm run ui`
4. `node server`
6. Test the navigation system
