### PR TITLE
Refactor: monthly_hours to total_expected_hours

### DIFF
--- a/api/models/Rate.js
+++ b/api/models/Rate.js
@@ -13,7 +13,7 @@ module.exports = (sequelize) => {
             autoIncrement: true,
             allowNull: false
         },
-        monthly_hours: {
+        total_expected_hours: {
             type: DataTypes.INTEGER
         },
         active: {

--- a/api/schema/types/RateType.js
+++ b/api/schema/types/RateType.js
@@ -7,13 +7,13 @@ module.exports = gql`
         hourly_rate: String!
         type: String!
         contributor_id: Int!
-        monthly_hours: Int
+        total_expected_hours: Int
         contributor: Contributor
     }
 
     input RateInput {
         active: Boolean
-        monthly_hours: Int
+        total_expected_hours: Int
         hourly_rate: String
         type: String
         contributor_id: Int

--- a/src/components/AllocationAddForm.js
+++ b/src/components/AllocationAddForm.js
@@ -69,7 +69,7 @@ const AllocationAddForm = (props) => {
             contributorRates,
             {
                 'hourly_rate': rate.hourly_rate.toString(),
-                'monthly_hours': Number(rate.monthly_hours),
+                'total_expected_hours': Number(rate.total_expected_hours),
                 'type': rate.type
             }
         )
@@ -80,7 +80,7 @@ const AllocationAddForm = (props) => {
             allocationRate['id'] = (await createRate({
                 variables: {
                     hourly_rate: rate.hourly_rate.toString(),
-                    monthly_hours: Number(rate.monthly_hours),
+                    total_expected_hours: Number(rate.total_expected_hours),
                     type: rate.type,
                     contributor_id: selectedContributor.id
                 }

--- a/src/components/RateProratedMonthlyForm.js
+++ b/src/components/RateProratedMonthlyForm.js
@@ -19,7 +19,7 @@ const RateProratedMonthlyForm = (props) => {
     useEffect(() => {
         setTotalWeeks(endDate.diff(startDate, 'weeks'))
         setCurrentRateInput(currentRate ? currentRate.hourly_rate : 0)
-        setMonthlyhoursInput(currentRate ? currentRate.monthly_hours : 160)
+        setMonthlyhoursInput(currentRate ? currentRate.total_expected_hours : 160)
     }, [currentRate])
 
     useEffect(() => {
@@ -30,7 +30,7 @@ const RateProratedMonthlyForm = (props) => {
         setTotalHours(totalAmount && currentRateInput ? (totalAmount / currentRateInput).toFixed(2) : 0)
         setNewAllocationRate({
             hourly_rate: currentRateInput,
-            monthly_hours: monthlyHoursInput,
+            total_expected_hours: monthlyHoursInput,
             total_amount: totalAmount,
             type: 'prorated_monthly'
         })

--- a/src/operations/mutations/RateMutations.js
+++ b/src/operations/mutations/RateMutations.js
@@ -1,10 +1,10 @@
 import { gql } from '@apollo/client'
 
 export const CREATE_RATE = gql`
-    mutation createRate($monthly_hours: Int, $hourly_rate: String!, $type: String!, $contributor_id: Int!){
+    mutation createRate($total_expected_hours: Int, $hourly_rate: String!, $type: String!, $contributor_id: Int!){
         createRate(createFields: {
             active: true
-            monthly_hours: $monthly_hours
+            total_expected_hours: $total_expected_hours
             hourly_rate: $hourly_rate
             type: $type
             contributor_id: $contributor_id

--- a/src/operations/queries/ContributorQueries.js
+++ b/src/operations/queries/ContributorQueries.js
@@ -44,7 +44,7 @@ export const GET_CONTRIBUTOR_ALLOCATIONS = gql`
                     active
                     type
                     hourly_rate
-                    monthly_hours
+                    total_expected_hours
                 }
             }
         }
@@ -61,7 +61,7 @@ export const GET_CONTRIBUTOR_RATES = gql`
                 active
                 type
                 hourly_rate
-                monthly_hours
+                total_expected_hours
             }
 
         }

--- a/src/operations/queries/ProjectQueries.js
+++ b/src/operations/queries/ProjectQueries.js
@@ -123,7 +123,7 @@ export const GET_PROJECT_CONTRIBUTOR_ALLOCATIONS = gql`
                 amount
                 rate {
                     id
-                    monthly_hours
+                    total_expected_hours
                     hourly_rate
                     type
                 }


### PR DESCRIPTION
Change requested in pr #229

@otech47 :
> If we rename this to just total_expected_hours then it still makes sense for how it's used but it could make sense as a more general field to do different rate types in the future for example prorated_weekly or something else

I made the necessary tests to make sure I wasn't breaking anything with the refactor