### PR TITLE
Bug resolved - GitHub acces token at login

### DIFF
--- a/api/modules/authentication.js
+++ b/api/modules/authentication.js
@@ -25,9 +25,20 @@ const authentication = module.exports = (() => {
         })
     }
 
+    const updateGithubAccessTokenContributor = async (githubContributor) => {
+        const contributor = await db.models.Contributor.findOne({
+            where: {
+                github_id: githubContributor.id
+            }
+        })
+        contributor.github_access_token = githubContributor.accessToken
+        return contributor.save()
+    }
+
     return {
         createContributor,
-        getContributor
+        getContributor,
+        updateGithubAccessTokenContributor
     }
 
 })()


### PR DESCRIPTION
### **Issue #235* - Bug resolved*

**Description:**

This pr contains the necessary changes to fix the bug described in #235. 

**What was happening:**

Basically, if a contributor was registered in the DB through the contributor's page (being directly fetched from Github) and then it tried to log in, he wouldn't be able to access the Github data because he wouldn't have the `github_access_token`

**How I fixed it:**

Now when a contributor logs in we don't only check if it's registered into the DB or not, but we also check if it has a value in the `github_access_token` attribute, if not the case we update the contributor adding the GitHub access token fetched from Github at the login.

**Breakdown:**

* Extra conditional statement asking if the `contributorInfo.contributor['github_access_token']` exists. (Implemented in `server.js`)
* New function `updateGithubAccessTokenContributor` that does what the name tells, updates de contributor with its access token (implemented in `api/modules/authentication.js`

**Magnitude:**

This bug was affecting production causing troubles displaying the data - not critical

**Prove of the bug fixing:**

https://www.loom.com/share/892e26a553bb493ea3b3c31f51dcacb6

**Additional:**

This should be tested by the whole team to make sure it works correctly