### PR TITLE
Bug resolved - GitHub name nonexistent at login

### DIFF
--- a/api/modules/authentication.js
+++ b/api/modules/authentication.js
@@ -1,3 +1,5 @@
+const { split } = require('lodash')
+
 const { fetchAuthUserData } = require('../handlers/github')
 const db = require('../models')
 
@@ -17,8 +19,10 @@ const authentication = module.exports = (() => {
     }
 
     const createContributor = async (githubContributor) => {
+        const githubContributorInfo = split(githubContributor.githubUrl, '/')
+        const githubContributorUsername = githubContributorInfo[githubContributorInfo.length - 1]
         return db.models.Contributor.create({
-            name: githubContributor.name,
+            name: githubContributor.name ? githubContributor.name : githubContributorUsername,
             github_id: githubContributor.id,
             github_handle: githubContributor.githubUrl,
             github_access_token: githubContributor.accessToken


### PR DESCRIPTION
### **Issue #236* - Bug resolved*

**Description:**

This pr contains the necessary changes to fix the bug described in #236 

**What was happening:**

When a GitHub user without a name tried to login into the app the application broke indicating that the contributor `name` attribute in the DB couldn't be `null`

**How I fixed it:**

Using the GitHub url I was getting the GitHub username, and at the moment of creating the contributor in the DB I check if the GitHub contributor has a name, and if not, I add the username instead as the `name` attribute value

**Breakdown:**

* Very simple implementation, I resolved the bug using the following logic in the `createContributor` function:
  `name: githubContributor.name ? githubContributor.name : githubContributorUsername`
   Implemented in `api/modules/authentication`

**Magnitude:**

This bug was affecting production causing troubles displaying the data - not critical

**Prove of the bug fixing:**

https://www.loom.com/share/191fc8123d53488c85dac71ca51d265b

