### PR TITLE
Bug resolved - Github owner credentials

### DIFF
--- a/api/modules/dataSyncs.js
+++ b/api/modules/dataSyncs.js
@@ -26,7 +26,7 @@ const dataSyncs = module.exports = (() => {
         const githubContributors = await github.fetchRepoContributors({
             auth_key: params.auth_key,
             repo: params.repo,
-            owner: GITHUB.OWNER,
+            owner: params.owner
         })
         await Promise.all(
             await githubContributors.map(async c => {
@@ -56,11 +56,11 @@ const dataSyncs = module.exports = (() => {
 
     const syncGithubIssues = async (params) => {
         const newIssues = []
-        const githubUrlSplitted = split(params.github_url, '/')
+        const repoInformation = split(params.github_url, '/')
         const issues = await github.fetchRepoIssues({
             auth_key: params.auth_key,
-            owner: githubUrlSplitted[githubUrlSplitted.length - 2],
-            repo: githubUrlSplitted[githubUrlSplitted.length - 1]
+            owner: repoInformation[repoInformation.length - 2],
+            repo: repoInformation[repoInformation.length - 1]
         })
         await Promise.all(
             issues.map(async i => {

--- a/api/schema/resolvers/ProjectResolver.js
+++ b/api/schema/resolvers/ProjectResolver.js
@@ -182,11 +182,11 @@ module.exports = {
             const authContributorKey = args.githubPersonalKey
                 ? args.githubPersonalKey
                 : (await models.Contributor.findByPk(cookies.userSession, { raw: true }))['github_access_token']
-            const urlSplitted = split(project.github_url, '/');
+            const repoInformation = split(project.github_url, '/');
             const issues = await github.fetchRepoIssues({
                 auth_key: authContributorKey,
-                repo: urlSplitted[urlSplitted.length - 1],
-                owner: GITHUB.OWNER
+                repo: repoInformation[repoInformation.length - 1],
+                owner: repoInformation[repoInformation.length - 2]
             })
             let openIssues = 0
             issues.map((i, n) => {
@@ -216,11 +216,11 @@ module.exports = {
             const authContributorKey = args.githubPersonalKey
                 ? args.githubPersonalKey
                 : (await models.Contributor.findByPk(cookies.userSession, { raw: true }))['github_access_token']
-            const urlSplitted = split(project.github_url, '/');
+            const repoInformation = split(project.github_url, '/');
             const issues = await github.fetchRepoIssues({
                 auth_key: authContributorKey,
-                repo: urlSplitted[urlSplitted.length - 1],
-                owner: GITHUB.OWNER
+                repo: repoInformation[repoInformation.length - 1],
+                owner: repoInformation[repoInformation.length - 2]
             })
             let closedIssues = 0
             issues.map((i, n) => {
@@ -440,6 +440,7 @@ module.exports = {
             const repo = split(project.github_url, '/')
             return dataSyncs.syncGithubRepoContributors({
                 auth_key: authContributorToken,
+                owner: repo[repo.length - 2],
                 repo: repo[repo.length - 1]
             })
         },


### PR DESCRIPTION
### **Issue #249* - Bug resolved*

**Description:**

This pr contains the necessary changes to fix the bug described in #249

**What was happening:**

When making requests to GitHub, we were using a fixed value for the owner `GITHUB_OWNER` that was set to SetLife owner name, causing that when we were making a request for a repo not owned by SetLife we were getting `bad_credentials` error from Github

**How I fixed it:**

I get the owner from the `github_url` attribute in the DB. 

**Magnitude:**

This bug was affecting production causing troubles displaying the data - not critical

**Prove of the bug fixing:**

This needs to be tested by a contributor with access to a repo not owned by Setlife. @otech47 may be able to test this. But I make sure that all the appearances of the `owner` constant were refactored.