### PR TITLE
Add Allocation week counter fix

### DIFF
--- a/src/components/RateMaxBudgetForm.js
+++ b/src/components/RateMaxBudgetForm.js
@@ -17,7 +17,7 @@ const RateMaxBudgetForm = (props) => {
     const [totalHours, setTotalHours] = useState(0)
 
     useEffect(() => {
-        setTotalWeeks(endDate.diff(startDate, 'weeks'))
+        setTotalWeeks(endDate.diff(startDate, 'days') / 7)
         setCurrentRateInput(currentRate ? currentRate.hourly_rate : 0)
     }, [])
 
@@ -31,7 +31,7 @@ const RateMaxBudgetForm = (props) => {
     }, [totalAmount, currentRateInput])
 
     useEffect(() => {
-        setTotalWeeks(endDate.diff(startDate, 'weeks'))
+        setTotalWeeks(endDate.diff(startDate, 'days') / 7)
     }, [startDate, endDate])
 
     return (

--- a/src/components/RateProratedMonthlyForm.js
+++ b/src/components/RateProratedMonthlyForm.js
@@ -17,7 +17,7 @@ const RateProratedMonthlyForm = (props) => {
     const [totalHours, setTotalHours] = useState(0)
 
     useEffect(() => {
-        setTotalWeeks(endDate.diff(startDate, 'weeks'))
+        setTotalWeeks(endDate.diff(startDate, 'days') / 7)
         setCurrentRateInput(currentRate ? currentRate.hourly_rate : 0)
         setMonthlyhoursInput(currentRate ? currentRate.monthly_hours : 160)
     }, [currentRate])
@@ -37,7 +37,7 @@ const RateProratedMonthlyForm = (props) => {
     }, [totalAmount])
 
     useEffect(() => {
-        setTotalWeeks(endDate.diff(startDate, 'weeks'))
+        setTotalWeeks(endDate.diff(startDate, 'days') / 7)
     }, [startDate, endDate])
 
     return (
@@ -49,6 +49,7 @@ const RateProratedMonthlyForm = (props) => {
                             <TextField
                                 label='Expected monthly hours'
                                 variant='filled'
+                                defaultValue='0'
                                 value={`${monthlyHoursInput}`}
                                 fullWidth
                                 onChange={(event) => setMonthlyhoursInput(event.target.value)}
@@ -77,7 +78,7 @@ const RateProratedMonthlyForm = (props) => {
             <Grid item xs={12}>
                 <Box mb={2} mt={1}>
                     <Typography>
-                        {`Total hours per week = ${(totalHours / totalWeeks).toFixed(2)}`}
+                        {`Total hours per week = ${Math.trunc((totalHours / totalWeeks))}`}
                     </Typography>
                 </Box>
             </Grid>


### PR DESCRIPTION
### **Issue #257**

**Description:**

This pr contains the necessary changes to fix the bug described in #257

**What was happening:**

The metrics displayed when creating the allocation where calculated by the wrong amount of the allocation duration weeks, causing that the metrics weren't correct.

**How I fixed it:**

Instead of counting the number of weeks using Lodash, I count the number of days and then divide them by 7
`setTotalWeeks(endDate.diff(startDate, 'days') / 7)`

**Prove of the bug fixing:**

Before:

<img width="632" alt="Screen Shot 2021-01-27 at 12 31 22 PM" src="https://user-images.githubusercontent.com/49292858/106021918-ab981400-609b-11eb-8c3b-8e66981bf1f4.png">

After (fixed):

<img width="519" alt="Screen Shot 2021-01-27 at 12 26 52 PM" src="https://user-images.githubusercontent.com/49292858/106021950-b3f04f00-609b-11eb-828f-84be38ab9301.png">
