### PR TITLE
Bug resolved - Add/edit client/project missing required fields

### DIFF
--- a/src/components/AddProjectForm.js
+++ b/src/components/AddProjectForm.js
@@ -39,7 +39,9 @@ const AddProjectForm = ({
     const [displayError, setDisplayError] = useState(false)
 
     useEffect(() => {
-        if (projectName && projectGithub && projectBudget && projectDate) {
+        if (!projectName || !projectGithub || !projectDate) {
+            setDisableAdd(true)
+        } else {
             setDisableAdd(false)
         }
     })

--- a/src/components/ClientAddForm.js
+++ b/src/components/ClientAddForm.js
@@ -50,7 +50,9 @@ const ClientAddForm = ({
     }
 
     useEffect(() => {
-        if (clientName && clientCurrency) {
+        if (!clientName || !clientCurrency) {
+            setDisableAdd(true)
+        } else {
             setDisableAdd(false)
         }
     })

--- a/src/components/ClientEditDialog.js
+++ b/src/components/ClientEditDialog.js
@@ -61,7 +61,12 @@ const ClientEditDialog = (props) => {
     }
 
     useEffect(() => {
-        if (clientName || clientCurrency || clientEmail) {
+
+        if (!clientName || !clientCurrency) {
+            setDisableEdit(true)
+        } else if (clientName == client.name && clientCurrency == client.currency && clientEmail == client.email) {
+            setDisableEdit(true)
+        } else {
             setDisableEdit(false)
         }
     })

--- a/src/components/ProjectEditDialog.js
+++ b/src/components/ProjectEditDialog.js
@@ -64,13 +64,13 @@ const ProjectEditDialog = (props) => {
 
     useEffect(() => {
         if (
-            expectedBudget == project.expected_budget && 
+            expectedBudget == project.expected_budget &&
             githubURL == project.github_url &&
             projectName == project.name &&
             togglURL == project.toggl_url
         ) {
             setDisableEdit(true)
-        } else if (expectedBudget == '' || githubURL == '' || projectName == '') {
+        } else if (!expectedBudget || !githubURL || !projectName) {
             setDisableEdit(true)
         } else {
             setDisableEdit(false)


### PR DESCRIPTION
### **Issue #245* - Bug resolved*

**Description:**

This pr contains the necessary changes to fix the bug described in #245

**What was happening:**

There was the possibility to create/edit a client/project without a required piece of information like name or GitHub URL

**How I fixed it:**

I make sure that if there's a required field missing, the add/edit button will be disabled

**Prove of the bug fixing:**

https://www.loom.com/share/dce107099ffa4a1099b4430d838b9726