### PR TITLE
Allocations query with more filters

### DIFF
--- a/api/schema/resolvers/AllocationResolver.js
+++ b/api/schema/resolvers/AllocationResolver.js
@@ -21,7 +21,16 @@ module.exports = {
             return models.Allocation.findByPk(id)
         },
         getAllocations: (root, args, { models }) => {
-            return models.Allocation.findAll()
+            const whereConditions = {}
+            if (args.contributorId) {
+                whereConditions['contributor_id'] = args.contributorId
+            }
+            if (args.projectId) {
+                whereConditions['project_id'] = args.projectId
+            }
+            return models.Allocation.findAll({
+                where: whereConditions
+            })
         }
     },
     Mutation: {

--- a/api/schema/types/AllocationType.js
+++ b/api/schema/types/AllocationType.js
@@ -43,7 +43,7 @@ module.exports = gql`
 
     type Query {
         getAllocationById(id: Int!): Allocation
-        getAllocations: [Allocation]
+        getAllocations(contributorId: Int, projectId: Int): [Allocation]
     }
 
     type Mutation {


### PR DESCRIPTION
### **Issue #281**

**Description:**

This pr contains the necessary changes for the getAllocations query accept `projectId` and `contributorId` as optional parameters. This is implemented because it's needed for #263.

**Breakdown**

* Query definition now takes two new parameters `getAllocations(contributorId: Int, projectId: Int): [Allocation]`
* `whereConditions` object on the `getAllocations` query resolver, conditionally adds the search parameters for when the query executes

**Proof of implementation**

* Without filter 
<img width="1440" alt="Screen Shot 2021-02-05 at 12 43 36 AM" src="https://user-images.githubusercontent.com/49292858/106990745-40a9a580-674b-11eb-85ae-109fec5f33b5.png">

* Filtering by `contributorId`
<img width="1440" alt="Screen Shot 2021-02-05 at 12 43 19 AM" src="https://user-images.githubusercontent.com/49292858/106990759-4901e080-674b-11eb-8140-9c88ce662f92.png">

* Filtering by `projectId`
<img width="1440" alt="Screen Shot 2021-02-05 at 12 45 33 AM" src="https://user-images.githubusercontent.com/49292858/106990879-87979b00-674b-11eb-947c-8a50daa4b90f.png">

* Filtering by `contributorId` and `projectId`
<img width="1440" alt="Screen Shot 2021-02-05 at 12 42 49 AM" src="https://user-images.githubusercontent.com/49292858/106990804-60d96480-674b-11eb-9cda-25faefda5767.png">

