### PR TITLE
Contributor page empty state

### DIFF
--- a/src/components/AllocationAddForm.js
+++ b/src/components/AllocationAddForm.js
@@ -370,8 +370,7 @@ const AllocationAddForm = (props) => {
     const activeContributors = activeAllocations.map(a => {
         return a.contributor
     })
-
-    if (!rateCurrency) {
+    if (!rateCurrency && clientCurrency) {
         setRateCurrency(clientCurrency)
     }
 

--- a/src/components/ContributorAllocations.js
+++ b/src/components/ContributorAllocations.js
@@ -9,6 +9,7 @@ import {
 
 import AllocationAddForm from './AllocationAddForm'
 import AllocationTile from './AllocationTile'
+import EmptyState from './EmptyState'
 import LoadingProgress from './LoadingProgress'
 import { GET_CONTRIBUTOR_ALLOCATIONS, GET_CONTRIBUTOR_INFO } from '../operations/queries/ContributorQueries'
 import { white } from '../styles/colors.scss'
@@ -88,7 +89,17 @@ const ContributorAllocations = (props) => {
                 </Grid>
                 <Grid item xs={12}>
                     <Grid container spacing={5}>
-                        {renderAllocations({ allocations: contributorAllocations.allocations })}
+                        {
+                            contributorAllocations.allocations.length
+                                ? renderAllocations({ allocations: contributorAllocations.allocations })
+                                : (
+                                    <EmptyState
+                                        description='This contributor has no allocations at the moment'
+                                        iconClassname='fas fa-money-check'
+                                    />
+                                )
+                        }
+
                     </Grid>
                 </Grid>
             </Grid>

--- a/src/components/ContributorAllocations.js
+++ b/src/components/ContributorAllocations.js
@@ -99,7 +99,6 @@ const ContributorAllocations = (props) => {
                                     />
                                 )
                         }
-
                     </Grid>
                 </Grid>
             </Grid>

--- a/src/components/ContributorAllocations.js
+++ b/src/components/ContributorAllocations.js
@@ -6,6 +6,7 @@ import {
     Grid,
     Typography
 } from '@material-ui/core'
+import { isEmpty } from 'lodash'
 
 import AllocationAddForm from './AllocationAddForm'
 import AllocationTile from './AllocationTile'
@@ -90,7 +91,7 @@ const ContributorAllocations = (props) => {
                 <Grid item xs={12}>
                     <Grid container spacing={5}>
                         {
-                            contributorAllocations.allocations.length
+                            !isEmpty(contributorAllocations.allocations)
                                 ? renderAllocations({ allocations: contributorAllocations.allocations })
                                 : (
                                     <EmptyState

--- a/src/components/ContributorProjectsCollab.js
+++ b/src/components/ContributorProjectsCollab.js
@@ -7,6 +7,7 @@ import {
     Typography
 } from '@material-ui/core'
 
+import EmptyState from './EmptyState'
 import LoadingProgress from './LoadingProgress'
 import ProjectTile from './ProjectTile'
 import { GET_CONTRIBUTOR_PROJECTS } from '../operations/queries/ContributorQueries'
@@ -56,11 +57,20 @@ const ContributorProjectsCollab = (props) => {
                 <Box my={5} mx={3}>
                     <Typography variant='h5' color='primary'>
                         <strong>
-                            {`Project Involvment`}
+                            {`Project Involvement`}
                         </strong>
                     </Typography>
                     <Grid container>
-                        {renderProjects({ projects: projects })}
+                        {
+                            projects.lenght
+                                ? renderProjects({ projects: projects })
+                                : (
+                                    <EmptyState
+                                        description='This contributor has no projects at the moment'
+                                        iconClassname='fas fa-code'
+                                    />
+                                )
+                        }
                     </Grid>
                 </Box>
             </Grid>

--- a/src/components/ContributorProjectsCollab.js
+++ b/src/components/ContributorProjectsCollab.js
@@ -32,8 +32,6 @@ const ContributorProjectsCollab = (props) => {
 
     const renderProjects = ({ propjects }) => {
         return projects.map(p => {
-            console.log('p');
-            console.log(p);
             return (
                 <Grid item xs={12} sm={6} md={3}>
                     <Box my={2}>

--- a/src/components/ContributorProjectsCollab.js
+++ b/src/components/ContributorProjectsCollab.js
@@ -6,6 +6,7 @@ import {
     Grid,
     Typography
 } from '@material-ui/core'
+import { isEmpty } from 'lodash'
 
 import EmptyState from './EmptyState'
 import LoadingProgress from './LoadingProgress'
@@ -62,7 +63,7 @@ const ContributorProjectsCollab = (props) => {
                     </Typography>
                     <Grid container>
                         {
-                            projects.lenght
+                            !isEmpty(projects)
                                 ? renderProjects({ projects: projects })
                                 : (
                                     <EmptyState

--- a/src/components/EmptyState.js
+++ b/src/components/EmptyState.js
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import {
+    Box,
+    Grid,
+    Icon,
+    Typography
+} from '@material-ui/core'
+import GroupAddIcon from '@material-ui/icons/GroupAdd';
+
+const EmptyState = (props) => {
+    const {
+        description,
+        iconClassname
+    } = props
+
+    return (
+        <Grid container justify='center' className='EmptyState'>
+            <Box mt={5}>
+                <Typography color='secondary' variant='h6'>
+                    {`${description}`}
+                </Typography>
+                <Box mt={5} align='center'>
+                    <Icon className={`${iconClassname} empty-icon`} color='secondary'/>
+                </Box>
+            </Box>
+        </Grid>
+    )
+}
+
+export default EmptyState


### PR DESCRIPTION
### **Issue #311**

**Description:**

This pr contains a very simple implementation, the empty states for the `ContributorDetailPage`

**Breakdown**

* I create a new component called `EmptyState` that takes a description and an icon classname (ideally from font awesome) as parameters and displays it as an empty state styled component. This component can be reused for all future empty states.

**Proof of implementation**

<img width="1440" alt="Screen Shot 2021-02-21 at 10 39 35 PM" src="https://user-images.githubusercontent.com/49292858/108718898-49dd9500-74f5-11eb-9463-9cfb160692b5.png">
