### PR TITLE
Allocations from Client Detail Page

### DIFF
--- a/src/components/AllocationAddForm.js
+++ b/src/components/AllocationAddForm.js
@@ -18,6 +18,7 @@ import moment from 'moment'
 import DatePicker from 'react-datepicker'
 
 import AllocationAddSpecifics from './AllocationAddSpecifics'
+import AllocationClientSpecifics from './AllocationClientSpecifics'
 import AllocationProposeSpecifics from './AllocationProposeSpecifics'
 import LoadingProgress from './LoadingProgress'
 import RateMaxBudgetForm from './RateMaxBudgetForm'
@@ -42,6 +43,7 @@ import { red } from '../styles/colors.scss'
 const AllocationAddForm = (props) => {
 
     const {
+        client,
         contributor,
         payment,
         project,
@@ -233,7 +235,7 @@ const AllocationAddForm = (props) => {
             setSelectedPayment(payment)
         }
         if (dataContributors) {
-            if (!contributor && !selectedContributor) {
+            if (!client && !contributor && !selectedContributor) {
                 setSelectedContributor(dataContributors[0])
             }
         }
@@ -246,7 +248,7 @@ const AllocationAddForm = (props) => {
 
     useEffect(() => {
         if (dataContributors) {
-            if (!contributor && !selectedContributor) {
+            if (!client && !contributor && !selectedContributor) {
                 setSelectedContributor(dataContributors.getContributors[0])
             }
         }
@@ -328,9 +330,11 @@ const AllocationAddForm = (props) => {
     const currency = (
         dataClientPayments
             ? dataClientPayments.getProjectById.client.currency
-            : selectedProject
-                ? selectedProject.client.currency
-                : null
+            : client
+                ? client.currency
+                : selectedProject
+                    ? selectedProject.client.currency
+                    : null
     )
     const rates = contributorRates
         ? dataContributorRates.getContributorById.rates
@@ -368,22 +372,33 @@ const AllocationAddForm = (props) => {
                                         setContributor={setSelectedContributor}
                                         setPayment={setSelectedPayment}
                                     />
-                                ) : (
-                                    <AllocationProposeSpecifics
-                                        contributor={contributor}
-                                        setNewAllocation={setNewAllocation}
-                                        setPayment={setSelectedPayment}
-                                        setProject={setSelectedProject}
-                                    />
                                 )
+                                : client
+                                    ? (
+                                        <AllocationClientSpecifics
+                                            client={client}
+                                            contributor={selectedContributor}
+                                            payment={payment}
+                                            project={selectedProject}
+                                            setNewAllocation={setNewAllocation}
+                                            setContributor={setSelectedContributor}
+                                            setProject={setSelectedProject}
+                                        />
+                                    )
+                                    : (
+                                        <AllocationProposeSpecifics
+                                            contributor={contributor}
+                                            setNewAllocation={setNewAllocation}
+                                            setPayment={setSelectedPayment}
+                                            setProject={setSelectedProject}
+                                        />
+                                    )
                         }
                         <hr/>
                     </Grid>
                     {
-                        selectedProject &&
-
+                        (selectedContributor) &&
                         <>
-
                             <Grid item xs={12}>
                                 <ButtonGroup color='primary' aria-label='outlined primary button group'>
                                     <Button
@@ -446,7 +461,7 @@ const AllocationAddForm = (props) => {
                     }
                 </Grid>
                 {
-                    selectedProject &&
+                    selectedContributor &&
                     <>
                         {
                             allocationTypes[0]

--- a/src/components/AllocationAddForm.js
+++ b/src/components/AllocationAddForm.js
@@ -387,8 +387,7 @@ const AllocationAddForm = (props) => {
                                             setContributor={setSelectedContributor}
                                             setProject={setSelectedProject}
                                         />
-                                    )
-                                    : (
+                                    ) : (
                                         <AllocationProposeSpecifics
                                             contributor={contributor}
                                             setNewAllocation={setNewAllocation}

--- a/src/components/AllocationAddForm.js
+++ b/src/components/AllocationAddForm.js
@@ -244,6 +244,9 @@ const AllocationAddForm = (props) => {
         } else {
             setSelectedProject(null)
         }
+        if (!contributor) {
+            setSelectedContributor(null)
+        }
     }, [open])
 
     useEffect(() => {

--- a/src/components/AllocationClientSpecifics.js
+++ b/src/components/AllocationClientSpecifics.js
@@ -1,0 +1,272 @@
+import React, { useEffect, useState } from 'react'
+import { useQuery } from '@apollo/client'
+import {
+    Box,
+    Button,
+    Collapse,
+    Grid,
+    List,
+    ListItem,
+    ListItemIcon,
+    ListItemText,
+    Typography
+} from '@material-ui/core/'
+import {
+    ExpandLess,
+    ExpandMore
+} from '@material-ui/icons'
+import AssessmentIcon from '@material-ui/icons/Assessment'
+import GitHubIcon from '@material-ui/icons/GitHub'
+import PaymentIcon from '@material-ui/icons/Payment'
+import PeopleIcon from '@material-ui/icons/Group'
+import moment from 'moment'
+import {
+    differenceBy,
+    differenceWith,
+    last,
+    split
+} from 'lodash'
+
+import LoadingProgress from './LoadingProgress'
+import { GET_CLIENT_PROJECTS } from '../operations/queries/ClientQueries'
+import {
+    formatAmount,
+    selectCurrencyInformation
+} from '../scripts/selectors'
+
+const AllocationClientSpecifics = (props) => {
+
+    const {
+        client,
+        contributor,
+        payment,
+        project,
+        setContributor,
+        setProject,
+        setNewAllocation
+    } = props
+
+    const {
+        data: dataProjects,
+        error: errorProjects,
+        loading: loadingProjects
+    } = useQuery(GET_CLIENT_PROJECTS, {
+        variables: {
+            id: client.id
+        }
+    })
+
+    const [openContributorsList, setOpenContributorsList] = useState(false)
+    const [openProjectsList, setOpenProjectsList] = useState(false)
+    const [selectedContributor, setSelectedContributor] = useState(null)
+    const [selectedProject, setSelectedProject] = useState(null)
+
+    useEffect(() => {
+        if (selectedProject) {
+            setProject(selectedProject)
+        }
+        if (selectedContributor) {
+            setContributor(selectedContributor)
+        }
+    })
+    useEffect(() => {
+        if (contributor) {
+            setSelectedContributor(contributor)
+        }
+    }, [contributor])
+    useEffect(() => {
+        if (project) {
+            setSelectedProject(project)
+        }
+    }, [project])
+    useEffect(() => {
+        if (selectedContributor && selectedProject) {
+            setNewAllocation({
+                payment_id: payment.id,
+                project_id: selectedProject.id
+            })
+        }
+    }, [selectedContributor, selectedProject])
+
+    const handleClickContributorsList = () => {
+        setOpenContributorsList(!openContributorsList)
+    }
+    const handleClickProjectsList = () => {
+        setOpenProjectsList(!openProjectsList)
+    }
+    const onClickProject = ({ project }) => {
+        setSelectedProject(project)
+        setOpenProjectsList(false)
+    }
+    const onClickContributor = ({ contributor }) => {
+        setSelectedContributor(contributor)
+        setOpenContributorsList(false)
+    }
+
+    const listContributors = (contributors) => {
+        const contributorsList = differenceWith(contributors, [selectedContributor])
+        return contributorsList.map(c => {
+            return (
+                <List component='div' disablePadding>
+                    <ListItem button onClick={() => onClickContributor({ contributor: c })}>
+                        <Grid container>
+                            <Grid item xs={3}/>
+                            <Grid item xs={3}>
+                                <ListItemText primary={`${c.name}`}/>
+                            </Grid>
+                            <Grid item xs={3} align='center'>
+                                <Typography variant='caption' color='secondary'>
+                                    {`${last(split(c.github_handle, '/'))}`}
+                                </Typography>
+                            </Grid>
+                            <Grid item xs={3}>
+                                {
+                                    c.github_access_token &&
+                                    <GitHubIcon color='secondary' fontSize='small'/>
+                                }
+                            </Grid>
+                        </Grid>
+                    </ListItem>
+                </List>
+            )
+        })
+    }
+    const listProjects = ({ projects, selectedProject }) => {
+        const unselectedProjects = differenceBy(projects, [selectedProject], 'id')
+        return unselectedProjects.map(project => {
+            return (
+                <List component='div' disablePadding>
+                    <ListItem button onClick={() => onClickProject({ project })}>
+                        <Grid container>
+                            <Grid item xs={3}/>
+                            <Grid item xs={3}>
+                                <ListItemText primary={`${project.name}`}/>
+                            </Grid>
+                            <Grid item xs={3} align='center'>
+                                <Typography variant='caption' color='secondary'>
+                                    {`${last(split(project.github_url, '/'))}`}
+                                </Typography>
+                            </Grid>
+                        </Grid>
+                    </ListItem>
+                </List>
+            )
+        })
+    }
+
+    if (loadingProjects) return <LoadingProgress/>
+    if (errorProjects) return `${errorProjects}`
+
+    const { projects } = dataProjects.getClientById
+    const contributors = selectedProject ? selectedProject.contributors : []
+    const currencyInformation = selectCurrencyInformation({
+        currency: client.currency
+    })
+    const paymentAmount = formatAmount({
+        amount: payment.amount / 100,
+        currencyInformation: currencyInformation
+    })
+    const githubProjectHandle = selectedProject ? last(split(selectedProject.github_url, '/')) : ''
+    const githubContributorHandle = selectedContributor ? last(split(selectedContributor.github_handle, '/')) : ''
+
+    return (
+        <Box className='AllocationClientSpecifics'>
+            <Grid container justify='center'>
+                <Grid item xs={12}>
+                    <List component='nav'>
+                        <ListItem>
+                            <Grid container>
+                                <Grid item xs={3}>
+                                    <PaymentIcon color='primary'/>
+                                </Grid>
+                                <Grid item xs={3}>
+                                    <Typography>
+                                        {`${paymentAmount}`}
+                                    </Typography>
+                                </Grid>
+                                <Grid item xs={6} align='center'>
+                                    <Typography variant='caption' color='secondary'>
+                                        {`${payment.date_paid
+                                            ? moment(payment.date_paid, 'x').format('MM/DD/YYYY')
+                                            : ''
+                                        }`}
+                                        {`${
+                                            !payment.date_paid && payment.date_incurred
+                                                ? 'Warning: This payment has not been paid'
+                                                : ''
+
+                                        }`}
+                                    </Typography>
+                                </Grid>
+                            </Grid>
+                        </ListItem>
+                    </List>
+                </Grid>
+
+                <Grid item xs={12}>
+                    <List component='nav'>
+                        <ListItem button onClick={handleClickProjectsList}>
+                            <Grid container>
+                                <Grid item xs={3}>
+                                    <AssessmentIcon color='primary'/>
+                                </Grid>
+                                <Grid item xs={3}>
+                                    <Typography>
+                                        {selectedProject ? selectedProject.name : 'No selected'}
+                                    </Typography>
+                                </Grid>
+                                <Grid item xs={3} align='center'>
+                                    <Typography variant='caption' color='secondary'>
+                                        {`${githubProjectHandle}`}
+                                    </Typography>
+                                </Grid>
+                                <Grid item xs={3} align='right'>
+                                    {openProjectsList
+                                        ? <ExpandLess />
+                                        : <ExpandMore />
+                                    }
+                                </Grid>
+                            </Grid>
+                        </ListItem>
+                        <Collapse in={openProjectsList} timeout='auto' unmountOnExit>
+                            {listProjects({
+                                projects,
+                                selectedProject: selectedProject
+                            })}
+                        </Collapse>
+                        <ListItem button onClick={handleClickContributorsList}>
+                            <Grid container>
+                                <Grid item xs={3}>
+                                    <PeopleIcon color='primary'/>
+                                </Grid>
+                                <Grid item xs={3}>
+                                    <Typography>
+                                        {selectedContributor ? selectedContributor.name : 'No selected'}
+                                    </Typography>
+                                </Grid>
+                                <Grid item xs={3} align='center'>
+                                    <Typography variant='caption' color='secondary'>
+                                        {`${githubContributorHandle}`}
+                                    </Typography>
+                                </Grid>
+                                <Grid item xs={3} align='right'>
+                                    {openContributorsList
+                                        ? <ExpandLess />
+                                        : <ExpandMore />
+                                    }
+                                </Grid>
+                            </Grid>
+                        </ListItem>
+                        <Collapse in={openContributorsList} timeout='auto' unmountOnExit>
+                            {listContributors(contributors)}
+                        </Collapse>
+                    </List>
+                </Grid>
+
+            </Grid>
+        </Box>
+    )
+
+}
+
+export default AllocationClientSpecifics

--- a/src/components/AllocationClientSpecifics.js
+++ b/src/components/AllocationClientSpecifics.js
@@ -68,6 +68,9 @@ const AllocationClientSpecifics = (props) => {
         if (selectedContributor) {
             setContributor(selectedContributor)
         }
+        if (!contributor) {
+            setSelectedContributor(null)
+        }
     })
     useEffect(() => {
         if (contributor) {

--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -200,39 +200,40 @@ const PaymentTile = (props) => {
                             color='primary'
                             onClick={() => handleEditPayment(true)}
                         >
-                            {'Edit'.toUpperCase()}
+                            {'Edit Payment'.toUpperCase()}
                         </Button>
                     </Box>
                 }
-                { project &&
-                    <AccordionDetails>
-                        <Grid container>
-                            <Grid item xs={12}>
-                                {renderPaymentAllocations({
-                                    allocations: allocations,
-                                    currencyInformation: currencyInformation
-                                })}
-                            </Grid>
-                            <Grid item xs={12}>
-                                <Button
-                                    fullWidth
-                                    color='primary'
-                                    variant='outlined'
-                                    onClick={() => addAllocation({ payment })}
-                                >
-                                    <Typography>
-                                        {`Allocate`}
-                                    </Typography>
-                                </Button>
-                            </Grid>
+
+                <AccordionDetails>
+                    <Grid container>
+                        <Grid item xs={12}>
+                            {renderPaymentAllocations({
+                                allocations: allocations,
+                                currencyInformation: currencyInformation
+                            })}
                         </Grid>
-                    </AccordionDetails>
-                }
+                        <Grid item xs={12}>
+                            <Button
+                                fullWidth
+                                color='primary'
+                                variant='outlined'
+                                onClick={() => addAllocation({ payment })}
+                            >
+                                <Typography>
+                                    {`Allocate`}
+                                </Typography>
+                            </Button>
+                        </Grid>
+                    </Grid>
+                </AccordionDetails>
+
             </Accordion>
             {
-                (paymentClicked && project) &&
+                paymentClicked &&
                 <AllocationAddForm
-                    project={project}
+                    client={client}
+                    project={project ? project : null}
                     open={openAddAllocationDialog}
                     onClose={handleAddAllocationClose}
                     payment={paymentClicked}

--- a/src/operations/queries/ClientQueries.js
+++ b/src/operations/queries/ClientQueries.js
@@ -22,6 +22,26 @@ export const GET_CLIENT_INFO = gql`
         }
     }
 `
+
+export const GET_CLIENT_PROJECTS = gql`
+    query ClientProjects($id: Int!) {
+        getClientById(id: $id){
+            id,
+            projects {
+                id
+                name
+                is_active
+                github_url
+                contributors {
+                    id
+                    name
+                    github_handle
+                }
+            }
+        }
+    }
+`
+
 export const GET_CLIENT_TOTAL_PAID = gql`
     query ClientTotalPaid($id: Int!, $fromDate: String, $toDate: String) {
         getClientById(id: $id){


### PR DESCRIPTION
### **Issue #311**

**Description**

This pr contains the necessary changes to be able to create an allocation directly from the `clientDetailPage`. I'm reusing the same component `AllocationAddForm` used multiple times all over the app to create allocations, but I had to make some tweaks to it to be able to pass it the necessary data.

**Breakdown**

* The new `AllocationClientSpecifics` component works as the form above `AllocationAddForm` to set the project and the contributor.
* The `PaymenTile` at the `ClientDetailPage` now has the Add Allocation button that pops up the modal with the `AllocationClientSpecifics` to create a new one

**Proof of implementation**

https://www.loom.com/share/918b3e234bc54f8e87b2ece84d451e11

**Note**

I will open an issue to clean up the `AllocationAddForm` since it got really big and at the beginning, I wasn't expecting to use it so much






