### PR TITLE
Update allocations instantly

### DIFF
--- a/src/components/AllocationAddForm.js
+++ b/src/components/AllocationAddForm.js
@@ -32,7 +32,10 @@ import {
     GET_PROJECT_CONTRIBUTORS,
     GET_PROJECT_CLIENT_PAYMENTS
 } from '../operations/queries/ProjectQueries'
-import { GET_PAYMENT_TOTAL_ALLOCATED } from '../operations/queries/PaymentQueries'
+import {
+    GET_PAYMENT_ALLOCATIONS,
+    GET_PAYMENT_TOTAL_ALLOCATED
+} from '../operations/queries/PaymentQueries'
 import { GET_ALLOCATIONS } from '../operations/queries/AllocationQueries'
 import { CREATE_RATE } from '../operations/mutations/RateMutations'
 import { CREATE_ALLOCATION } from '../operations/mutations/AllocationMutations'
@@ -222,6 +225,16 @@ const AllocationAddForm = (props) => {
                 contributorId: contributor ? contributor.id : null,
                 projectId: project ? project.id : null
 
+            }
+        }, {
+            query: GET_PAYMENT_ALLOCATIONS,
+            variables: {
+                paymentId: selectedPayment ? selectedPayment.id : null
+            }
+        }, {
+            query: GET_PAYMENT_TOTAL_ALLOCATED,
+            variables: {
+                paymentId: selectedPayment ? selectedPayment.id : null
             }
         }]
     })

--- a/src/components/AllocationAddForm.js
+++ b/src/components/AllocationAddForm.js
@@ -30,7 +30,8 @@ import {
 } from '../operations/queries/ContributorQueries'
 import {
     GET_PROJECT_CONTRIBUTORS,
-    GET_PROJECT_CLIENT_PAYMENTS
+    GET_PROJECT_CLIENT_PAYMENTS,
+    GET_PROJECT_PAYMENTS
 } from '../operations/queries/ProjectQueries'
 import {
     GET_PAYMENT_ALLOCATIONS,
@@ -235,6 +236,11 @@ const AllocationAddForm = (props) => {
             query: GET_PAYMENT_TOTAL_ALLOCATED,
             variables: {
                 paymentId: selectedPayment ? selectedPayment.id : null
+            }
+        }, {
+            query: GET_PROJECT_PAYMENTS,
+            variables: {
+                id: selectedProject ? Number(selectedProject.id) : null
             }
         }]
     })


### PR DESCRIPTION
### **Issue #303**

**Description:**

This pr contains a simple fix to re-fetch the allocations when a new one is created.

**Breakdown:**

* The queries `GET_PAYMENT_ALLOCATIONS` and `GET_PAYMENT_TOTAL_ALLOCATED` are recalled when the mutation `CREATE_ALLOCATION` is made

**Proof of implementation:** 

https://www.loom.com/share/1fd5429d06e04800ad24ec9692d6a2d3
