### PR TITLE
Delete payment functionality

### DIFF
--- a/src/components/ClientPayments.js
+++ b/src/components/ClientPayments.js
@@ -26,8 +26,7 @@ const ClientPayments = (props) => {
                 <PaymentsList
                     payments={payments}
                 />
-            )
-            : (
+            ) : (
                 <PaymentsEmptyState/>
             )
     )

--- a/src/components/DeleteConfirmationDialog.js
+++ b/src/components/DeleteConfirmationDialog.js
@@ -1,6 +1,6 @@
 import React from 'react'
-
 import {
+    Box,
     Button,
     Dialog,
     DialogActions,
@@ -9,35 +9,43 @@ import {
     DialogTitle
 } from '@material-ui/core/'
 
+import { red } from '../styles/colors.scss'
+
 const DeleteConfirmationDialog = (props) => {
 
     const {
+        deleteAction,
         deleteItem,
         onClose,
         open
     } = props
 
+    const handleConfirmAction = () => {
+        deleteAction()
+        onClose()
+    }
+
     return (
         <Dialog
             open={open}
             onClose={onClose}
-            aria-labelledby='alert-dialog-title'
-            aria-describedby='alert-dialog-description'
         >
             <DialogTitle>
                 {`Delete ${deleteItem}`}
             </DialogTitle>
             <DialogContent>
                 <DialogContentText id='alert-dialog-description'>
-                    {`Are you sure that you gant to delete this ${deleteItem}`}
+                    {`Are you sure that you want to delete this ${deleteItem}`}
                 </DialogContentText>
             </DialogContent>
             <DialogActions>
                 <Button onClick={onClose} color='primary'>
                     {`Cancel`}
                 </Button>
-                <Button onClick={onClose} color='primary'>
-                    {`Delete`}
+                <Button onClick={handleConfirmAction}>
+                    <Box color={`${red}`}>
+                        {`Delete`}
+                    </Box>
                 </Button>
             </DialogActions>
         </Dialog>

--- a/src/components/DeleteConfirmationDialog.js
+++ b/src/components/DeleteConfirmationDialog.js
@@ -1,0 +1,47 @@
+import React from 'react'
+
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle
+} from '@material-ui/core/'
+
+const DeleteConfirmationDialog = (props) => {
+
+    const {
+        deleteItem,
+        onClose,
+        open
+    } = props
+
+    return (
+        <Dialog
+            open={open}
+            onClose={onClose}
+            aria-labelledby='alert-dialog-title'
+            aria-describedby='alert-dialog-description'
+        >
+            <DialogTitle>
+                {`Delete ${deleteItem}`}
+            </DialogTitle>
+            <DialogContent>
+                <DialogContentText id='alert-dialog-description'>
+                    {`Are you sure that you gant to delete this ${deleteItem}`}
+                </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose} color='primary'>
+                    {`Cancel`}
+                </Button>
+                <Button onClick={onClose} color='primary'>
+                    {`Delete`}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    )
+}
+
+export default DeleteConfirmationDialog

--- a/src/components/DeletePayment.js
+++ b/src/components/DeletePayment.js
@@ -6,11 +6,13 @@ import {
 } from '@material-ui/core/'
 
 import DeleteConfirmationDialog from './DeleteConfirmationDialog'
+import { GET_CLIENT_PAYMENTS } from '../operations/queries/PaymentQueries'
 import { DELETE_PAYMENT } from '../operations/mutations/PaymentMutations'
 
 const DeletePayment = (props) => {
 
     const {
+        client,
         onClose,
         open,
         payment
@@ -20,7 +22,14 @@ const DeletePayment = (props) => {
         dataDeletedPayment,
         loadingDeletedPayment,
         errorDeletedPayment
-    }] = useMutation(DELETE_PAYMENT)
+    }] = useMutation(DELETE_PAYMENT, {
+        refetchQueries: [{
+            query: GET_CLIENT_PAYMENTS,
+            variables: {
+                clientId: Number(client.id)
+            }
+        }]
+    })
 
     const handleDeletePayment = async () => {
         const paymentDeleted = await deletePayment({

--- a/src/components/DeletePayment.js
+++ b/src/components/DeletePayment.js
@@ -1,0 +1,46 @@
+import React, { useState } from 'react'
+import { useMutation } from '@apollo/client'
+import {
+    Grid,
+    Typography
+} from '@material-ui/core/'
+
+import DeleteConfirmationDialog from './DeleteConfirmationDialog'
+import { DELETE_PAYMENT } from '../operations/mutations/PaymentMutations'
+
+const DeletePayment = (props) => {
+
+    const {
+        onClose,
+        open,
+        payment
+    } = props
+
+    const [deletePayment, {
+        dataDeletedPayment,
+        loadingDeletedPayment,
+        errorDeletedPayment
+    }] = useMutation(DELETE_PAYMENT)
+
+    const handleDeletePayment = async () => {
+        const paymentDeleted = await deletePayment({
+            variables: {
+                paymentId: Number(payment.id)
+            }
+        })
+    }
+
+    return (
+        <Grid container>
+            <DeleteConfirmationDialog
+                deleteAction={() => handleDeletePayment()}
+                deleteItem={`payment`}
+                payment={payment}
+                open={open}
+                onClose={onClose}
+            />
+        </Grid>
+    )
+}
+
+export default DeletePayment

--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -7,13 +7,16 @@ import {
     AccordionSummary,
     Box,
     Button,
+    Fab,
     Grid,
     Typography
 } from '@material-ui/core/'
+import DeleteOutlinedIcon from '@material-ui/icons/DeleteOutlined';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import MonetizationOnIcon from '@material-ui/icons/MonetizationOn'
 
 import AllocationAddForm from './AllocationAddForm'
+import DeleteConfirmationDialog from './DeleteConfirmationDialog'
 import PaymentEditDialog from './PaymentEditDialog'
 import {
     GET_PAYMENT_ALLOCATIONS,
@@ -55,14 +58,19 @@ const PaymentTile = (props) => {
 
     const [paymentClicked, setPaymentClicked] = useState(null)
     const [openAddAllocationDialog, setOpenAddAllocationDialog] = useState(false)
-    const [openEditPayment, setOpenEditPayment] = useState(false);
+    const [openDeletePayment, setOpenDeletePayment] = useState(false)
+    const [openEditPayment, setOpenEditPayment] = useState(false)
 
     const addAllocation = (props) => {
         setOpenAddAllocationDialog(true)
         setPaymentClicked(props.payment)
     }
-    const handleAddAllocationClose = (value) => {
+    const handleAddAllocationClose = () => {
         setOpenAddAllocationDialog(false)
+    }
+
+    const handleDeletePayment = (value) => {
+        setOpenDeletePayment(value)
     }
     const handleEditPayment = (value) => {
         setOpenEditPayment(value)
@@ -195,13 +203,26 @@ const PaymentTile = (props) => {
                     </Grid>
                 </AccordionSummary>
                 { !project &&
-                    <Box align='left' mb={2} ml={2}>
-                        <Button
-                            color='primary'
-                            onClick={() => handleEditPayment(true)}
-                        >
-                            {'Edit'.toUpperCase()}
-                        </Button>
+                    <Box align='left' mb={2} ml={2} pr={2}>
+                        <Grid container>
+                            <Grid item xs={6}>
+                                <Button
+                                    color='primary'
+                                    onClick={() => handleEditPayment(true)}
+                                >
+                                    {'Edit'.toUpperCase()}
+                                </Button>
+                            </Grid>
+                            <Grid item xs={6} align='right'>
+                                <Button
+                                    color='primary'
+                                    onClick={() => handleDeletePayment(true)}
+                                >
+                                    <DeleteOutlinedIcon color='primary'/>
+                                </Button>
+
+                            </Grid>
+                        </Grid>
                     </Box>
                 }
                 { project &&
@@ -242,6 +263,12 @@ const PaymentTile = (props) => {
                 payment={payment}
                 open={openEditPayment}
                 onClose={() => handleEditPayment(false)}
+            />
+            <DeleteConfirmationDialog
+                deleteItem={`payment`}
+                payment={payment}
+                open={openDeletePayment}
+                onClose={() => handleDeletePayment(false)}
             />
         </Box>
     )

--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -192,67 +192,66 @@ const PaymentTile = (props) => {
                                         color={`${!totalAllocated || totalAllocated > payment.amount ? 'red' : 'primary.main'}`}
                                     >
                                         {`
-                                        ${totalAllocated}
-                                        ${numberOfContributorsAllocated && `allocated to ${numberOfContributorsAllocated}`}
-                                        ${numberOfContributorsAllocated == 1 ? 'contributor' : 'contributors'}
-                                    `}
+                                            ${totalAllocated}
+                                            ${numberOfContributorsAllocated && `allocated to ${numberOfContributorsAllocated}`}
+                                            ${numberOfContributorsAllocated == 1 ? 'contributor' : 'contributors'}
+                                        `}
                                     </Box>
                                 </Typography>
                             </Grid>
                             }
                         </Grid>
                     </AccordionSummary>
-                    { !project &&
-                    <Box align='left' mb={2} ml={2}>
-                        <Grid container>
-                            <Grid item xs={6}>
-                                <Button
-                                    color='primary'
-                                    onClick={() => handleEditPayment(true)}
-                                >
-                                    {'Edit'.toUpperCase()}
-                                </Button>
-                            </Grid>
-                            <Grid item xs={6} align='right'>
-                                <Button
-                                    color='primary'
-                                    onClick={() => handleDeletePayment(true)}
-                                >
-                                    <DeleteOutlinedIcon color='primary'/>
-                                </Button>
+                    {!project &&
+                        <Box align='left' mb={2} ml={2}>
+                            <Grid container>
+                                <Grid item xs={6}>
+                                    <Button
+                                        color='primary'
+                                        onClick={() => handleEditPayment(true)}
+                                    >
+                                        {'Edit'.toUpperCase()}
+                                    </Button>
+                                </Grid>
+                                <Grid item xs={6} align='right'>
+                                    <Button
+                                        color='primary'
+                                        onClick={() => handleDeletePayment(true)}
+                                    >
+                                        <DeleteOutlinedIcon color='primary'/>
+                                    </Button>
 
+                                </Grid>
                             </Grid>
-                        </Grid>
-                    </Box>
+                        </Box>
                     }
-                    { project &&
-                    <AccordionDetails>
-                        <Grid container>
-                            <Grid item xs={12}>
-                                {renderPaymentAllocations({
-                                    allocations: allocations,
-                                    currencyInformation: currencyInformation
-                                })}
+                    {project &&
+                        <AccordionDetails>
+                            <Grid container>
+                                <Grid item xs={12}>
+                                    {renderPaymentAllocations({
+                                        allocations: allocations,
+                                        currencyInformation: currencyInformation
+                                    })}
+                                </Grid>
+                                <Grid item xs={12}>
+                                    <Button
+                                        fullWidth
+                                        color='primary'
+                                        variant='outlined'
+                                        onClick={() => addAllocation({ payment })}
+                                    >
+                                        <Typography>
+                                            {`Allocate`}
+                                        </Typography>
+                                    </Button>
+                                </Grid>
                             </Grid>
-                            <Grid item xs={12}>
-                                <Button
-                                    fullWidth
-                                    color='primary'
-                                    variant='outlined'
-                                    onClick={() => addAllocation({ payment })}
-                                >
-                                    <Typography>
-                                        {`Allocate`}
-                                    </Typography>
-                                </Button>
-                            </Grid>
-                        </Grid>
-                    </AccordionDetails>
+                        </AccordionDetails>
                     }
                 </Accordion>
             </Box>
-            {
-                (paymentClicked && project) &&
+            {(paymentClicked && project) &&
                 <AllocationAddForm
                     project={project}
                     open={openAddAllocationDialog}

--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -16,7 +16,7 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import MonetizationOnIcon from '@material-ui/icons/MonetizationOn'
 
 import AllocationAddForm from './AllocationAddForm'
-import DeleteConfirmationDialog from './DeleteConfirmationDialog'
+import DeletePayment from './DeletePayment'
 import PaymentEditDialog from './PaymentEditDialog'
 import {
     GET_PAYMENT_ALLOCATIONS,
@@ -80,7 +80,6 @@ const PaymentTile = (props) => {
     })
 
     if (loadingTotalAllocated || loadingPaymentAllocations) return ''
-
     if (errorTotalAllocated || errorPaymentAllocations) return `An error ocurred`
 
     const { allocations } = dataPaymentAllocations.getPaymentById
@@ -145,46 +144,47 @@ const PaymentTile = (props) => {
     }
 
     return (
-        <Box
-            borderRadius='borderRadius'
-            bgcolor='primary.light'
-            mx={1}
-            className='PaymentTile'
-        >
-            <Accordion>
-                <AccordionSummary
-                    expandIcon={
-                        project &&
+        <div>
+            <Box
+                borderRadius='borderRadius'
+                bgcolor='primary.light'
+                mx={1}
+                className='PaymentTile'
+            >
+                <Accordion>
+                    <AccordionSummary
+                        expandIcon={
+                            project &&
                             <ExpandMoreIcon />
-                    }
-                >
-                    <Grid container alignItems='center'>
-                        <Grid item xs={5} align='left'>
-                            <Typography variant='h6'>
-                                {
-                                    `${paymentAmount}`
-                                }
-                            </Typography>
-                        </Grid>
-                        <Grid item xs={1}>
-                            <Typography
-                                variant='caption'
-                                align='left'
-                                color='secondary'
-                            >
-                                {
-                                    `${paymentHasBeenMade
-                                        ? formattedDatePaid
-                                        : formattedDateIncurred}`
-                                }
-                            </Typography>
-                        </Grid>
-                        <Grid item xs={6} align='right'>
-                            <MonetizationOnIcon
-                                color={`${paymentHasBeenMade ? 'primary' : 'secondary'}`}
-                            />
-                        </Grid>
-                        {project &&
+                        }
+                    >
+                        <Grid container alignItems='center'>
+                            <Grid item xs={5} align='left'>
+                                <Typography variant='h6'>
+                                    {
+                                        `${paymentAmount}`
+                                    }
+                                </Typography>
+                            </Grid>
+                            <Grid item xs={1}>
+                                <Typography
+                                    variant='caption'
+                                    align='left'
+                                    color='secondary'
+                                >
+                                    {
+                                        `${paymentHasBeenMade
+                                            ? formattedDatePaid
+                                            : formattedDateIncurred}`
+                                    }
+                                </Typography>
+                            </Grid>
+                            <Grid item xs={6} align='right'>
+                                <MonetizationOnIcon
+                                    color={`${paymentHasBeenMade ? 'primary' : 'secondary'}`}
+                                />
+                            </Grid>
+                            {project &&
                             <Grid item xs={12}>
                                 <Typography variant='subtitle1'>
                                     <Box
@@ -199,11 +199,11 @@ const PaymentTile = (props) => {
                                     </Box>
                                 </Typography>
                             </Grid>
-                        }
-                    </Grid>
-                </AccordionSummary>
-                { !project &&
-                    <Box align='left' mb={2} ml={2} pr={2}>
+                            }
+                        </Grid>
+                    </AccordionSummary>
+                    { !project &&
+                    <Box align='left' mb={2} ml={2}>
                         <Grid container>
                             <Grid item xs={6}>
                                 <Button
@@ -224,8 +224,8 @@ const PaymentTile = (props) => {
                             </Grid>
                         </Grid>
                     </Box>
-                }
-                { project &&
+                    }
+                    { project &&
                     <AccordionDetails>
                         <Grid container>
                             <Grid item xs={12}>
@@ -248,8 +248,9 @@ const PaymentTile = (props) => {
                             </Grid>
                         </Grid>
                     </AccordionDetails>
-                }
-            </Accordion>
+                    }
+                </Accordion>
+            </Box>
             {
                 (paymentClicked && project) &&
                 <AllocationAddForm
@@ -264,13 +265,12 @@ const PaymentTile = (props) => {
                 open={openEditPayment}
                 onClose={() => handleEditPayment(false)}
             />
-            <DeleteConfirmationDialog
-                deleteItem={`payment`}
+            <DeletePayment
                 payment={payment}
                 open={openDeletePayment}
                 onClose={() => handleDeletePayment(false)}
             />
-        </Box>
+        </div>
     )
 }
 

--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -266,9 +266,10 @@ const PaymentTile = (props) => {
                 onClose={() => handleEditPayment(false)}
             />
             <DeletePayment
-                payment={payment}
+                client={client}
                 open={openDeletePayment}
                 onClose={() => handleDeletePayment(false)}
+                payment={payment}
             />
         </div>
     )

--- a/src/operations/mutations/PaymentMutations.js
+++ b/src/operations/mutations/PaymentMutations.js
@@ -13,6 +13,13 @@ export const CREATE_PAYMENT = gql`
         }
     }
 `
+
+export const DELETE_PAYMENT = gql`
+    mutation DeletePayment($paymentId: Int!) {
+        deletePaymentById(id: $paymentId)
+    }
+`
+
 export const EDIT_PAYMENT = gql`
     mutation EditPayment($id: Int!, $amount: Int!, $date_incurred: String!, $date_paid: String) {
         updatePaymentById(id: $id, updateFields: {


### PR DESCRIPTION
### **Issue #322**

**Description:**

This pr contains the necessary changes to be able to delete a payment

**Important:**

Rn, when a payment is deleted, all the corresponding payments that were depending on this payment are also deleted by the SQL database, it has the configuration of _delete on cascade_

**Breakdown:**

* The new component `DeleteConfirmationDialog` is an entire UI component that is made having in mind that could be reused in multiple parts of the app, that's why I tried to make it as abstract as possible
* The `DeletePayment` component is more a logic component than a UI component, and it's the middle layer between the `PaymentTile` and the `DeleteConfirmationDialog`. Has the mutation to delete a payment given its `id`. Is the logic layer that customizes the `DeleteConfirmationDialog`
* The `PaymentTile` now renders a delete button if the app matches the route `/clients/:clientId`
* The `DELETE_PAYMENT ` apollo client mutation created on `PaymentMutations` takes the id of the payment to delete and returns the number of payments deleted

**Proof of implementation:**

https://www.loom.com/share/6accf1b1f5e44896b34a672407615bed
