### PR TITLE
Rate currency

### DIFF
--- a/api/migrations/20210223183216-addCurrencyToRates.js
+++ b/api/migrations/20210223183216-addCurrencyToRates.js
@@ -1,0 +1,19 @@
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        return queryInterface.sequelize.transaction(t => {
+            return Promise.all([
+                queryInterface.addColumn('Rates', 'currency', {
+                    type: Sequelize.DataTypes.STRING
+                }, { transaction: t })
+            ])
+        })
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        return queryInterface.sequelize.transaction(t => {
+            return Promise.all([
+                queryInterface.removeColumn('Rates', 'currency', { transaction: t })
+            ])
+        })
+    }
+};

--- a/api/models/Rate.js
+++ b/api/models/Rate.js
@@ -28,6 +28,10 @@ module.exports = (sequelize) => {
             type: DataTypes.STRING,
             allowNull: false
         },
+        currency: {
+            type: DataTypes.STRING,
+            allowNull: false
+        },
         contributor_id: { //FK
             type: DataTypes.INTEGER(11),
             references: {

--- a/api/models/Rate.js
+++ b/api/models/Rate.js
@@ -29,8 +29,7 @@ module.exports = (sequelize) => {
             allowNull: false
         },
         currency: {
-            type: DataTypes.STRING,
-            allowNull: false
+            type: DataTypes.STRING
         },
         contributor_id: { //FK
             type: DataTypes.INTEGER(11),

--- a/api/schema/resolvers/RateResolver.js
+++ b/api/schema/resolvers/RateResolver.js
@@ -1,5 +1,4 @@
 module.exports = {
-
     Rate: {
         contributor: (rate, args, { models }) => {
             return models.Contributor.findByPk(rate.contributor_id)

--- a/api/schema/types/RateType.js
+++ b/api/schema/types/RateType.js
@@ -8,6 +8,7 @@ module.exports = gql`
         type: String!
         contributor_id: Int!
         total_expected_hours: Int
+        currency: String
         contributor: Contributor
     }
 
@@ -16,6 +17,7 @@ module.exports = gql`
         total_expected_hours: Int
         hourly_rate: String
         type: String
+        currency: String
         contributor_id: Int
     }
 

--- a/src/components/AllocationAddForm.js
+++ b/src/components/AllocationAddForm.js
@@ -70,21 +70,24 @@ const AllocationAddForm = (props) => {
             {
                 'hourly_rate': rate.hourly_rate.toString(),
                 'total_expected_hours': Number(rate.total_expected_hours),
-                'type': rate.type
+                'type': rate.type,
+                'currency': rateCurrency
             }
         )
         if (existingRate != null) {
             //create only allocation referencing contributorRates[existingRate].id
             allocationRate['id'] = contributorRates[`${existingRate}`].id
         } else {
-            allocationRate['id'] = (await createRate({
-                variables: {
-                    hourly_rate: rate.hourly_rate.toString(),
-                    total_expected_hours: Number(rate.total_expected_hours),
-                    type: rate.type,
-                    contributor_id: selectedContributor.id
-                }
-            })).data.createRate.id
+            allocationRate['id'] = (
+                await createRate({
+                    variables: {
+                        hourly_rate: rate.hourly_rate.toString(),
+                        total_expected_hours: Number(rate.total_expected_hours),
+                        type: rate.type,
+                        currency: rateCurrency,
+                        contributor_id: selectedContributor.id
+                    }
+                })).data.createRate.id
         }
         //create allocation with that rate id
         const allocationCreated = await createAllocation({
@@ -195,6 +198,7 @@ const AllocationAddForm = (props) => {
     const [mostRecentAllocation, setMostRecentAllocation] = useState(null)
     const [newAllocationRate, setNewAllocationRate] = useState({})
     const [newAllocation, setNewAllocation] = useState({})
+    const [rateCurrency, setRateCurrency] = useState(null)
     const [startDate, setStartDate] = useState(moment().add(1, 'months').startOf('month')['_d'])
     const [selectedContributor, setSelectedContributor] = useState(null)
     const [selectedProject, setSelectedProject] = useState(null)
@@ -325,7 +329,7 @@ const AllocationAddForm = (props) => {
     const payments = dataClientPayments
         ? [...dataClientPayments.getProjectById.client.payments, { amount: null, date_paid: null }]
         : [null]
-    const currency = (
+    const clientCurrency = (
         dataClientPayments
             ? dataClientPayments.getProjectById.client.currency
             : selectedProject
@@ -340,6 +344,10 @@ const AllocationAddForm = (props) => {
     const activeContributors = activeAllocations.map(a => {
         return a.contributor
     })
+
+    if (!rateCurrency) {
+        setRateCurrency(clientCurrency)
+    }
 
     return (
         <Dialog
@@ -359,7 +367,7 @@ const AllocationAddForm = (props) => {
                                     <AllocationAddSpecifics
                                         contributor={contributor}
                                         contributors={contributors}
-                                        currency={currency}
+                                        currency={clientCurrency}
                                         payment={payment}
                                         payments={payments}
                                         project={project}
@@ -381,9 +389,7 @@ const AllocationAddForm = (props) => {
                     </Grid>
                     {
                         selectedProject &&
-
                         <>
-
                             <Grid item xs={12}>
                                 <ButtonGroup color='primary' aria-label='outlined primary button group'>
                                     <Button
@@ -452,15 +458,16 @@ const AllocationAddForm = (props) => {
                             allocationTypes[0]
                                 ? (
                                     <RateProratedMonthlyForm
-                                        currency={currency}
+                                        clientCurrency={clientCurrency}
                                         currentRate={mostRecentAllocation ? mostRecentAllocation.rate : null}
                                         setNewAllocationRate={setNewAllocationRate}
+                                        setCurrency={setRateCurrency}
                                         startDate={moment(startDate)}
                                         endDate={moment(endDate)}
                                     />
                                 ) : (
                                     <RateMaxBudgetForm
-                                        currency={currency}
+                                        clientCurrency={clientCurrency}
                                         currentRate={mostRecentAllocation ? mostRecentAllocation.rate : null}
                                         setNewAllocationRate={setNewAllocationRate}
                                         startDate={moment(startDate)}

--- a/src/components/AllocationAddForm.js
+++ b/src/components/AllocationAddForm.js
@@ -469,6 +469,7 @@ const AllocationAddForm = (props) => {
                                     <RateMaxBudgetForm
                                         clientCurrency={clientCurrency}
                                         currentRate={mostRecentAllocation ? mostRecentAllocation.rate : null}
+                                        setCurrency={setRateCurrency}
                                         setNewAllocationRate={setNewAllocationRate}
                                         startDate={moment(startDate)}
                                         endDate={moment(endDate)}

--- a/src/components/RateMaxBudgetForm.js
+++ b/src/components/RateMaxBudgetForm.js
@@ -21,6 +21,7 @@ const RateMaxBudgetForm = (props) => {
         currentRate,
         createRate,
         endDate,
+        setCurrency,
         setNewAllocationRate,
         startDate
     } = props
@@ -31,6 +32,11 @@ const RateMaxBudgetForm = (props) => {
     const [totalWeeks, setTotalWeeks] = useState(null)
     const [totalHours, setTotalHours] = useState(0)
 
+    useEffect(() => {
+        if (rateCurrency) {
+            setCurrency(rateCurrency)
+        }
+    }, [rateCurrency])
     useEffect(() => {
         setTotalWeeks(endDate.diff(startDate, 'days') / 7)
         setCurrentRateInput(currentRate ? currentRate.hourly_rate : 0)

--- a/src/components/RateMaxBudgetForm.js
+++ b/src/components/RateMaxBudgetForm.js
@@ -40,6 +40,7 @@ const RateMaxBudgetForm = (props) => {
     useEffect(() => {
         setTotalWeeks(endDate.diff(startDate, 'days') / 7)
         setCurrentRateInput(currentRate ? currentRate.hourly_rate : 0)
+        setRateCurrency(currentRate ? currentRate.currency : clientCurrency)
     }, [currentRate])
 
     useEffect(() => {

--- a/src/components/RateMaxBudgetForm.js
+++ b/src/components/RateMaxBudgetForm.js
@@ -1,19 +1,23 @@
 import React, { useEffect, useState } from 'react'
 import {
     Box,
+    FormHelperText,
     Grid,
+    MenuItem,
+    Select,
     TextField,
     Typography
 } from '@material-ui/core/'
 import moment from 'moment'
 import CurrencyTextField from '@unicef/material-ui-currency-textfield'
 
+import { CURRENCIES } from '../constants'
 import { selectCurrencyInformation } from '../scripts/selectors'
 
 const RateMaxBudgetForm = (props) => {
 
     const {
-        currency,
+        clientCurrency,
         currentRate,
         createRate,
         endDate,
@@ -21,8 +25,9 @@ const RateMaxBudgetForm = (props) => {
         startDate
     } = props
 
-    const [totalAmount, setTotalAmount] = useState(0)
     const [currentRateInput, setCurrentRateInput] = useState(null)
+    const [rateCurrency, setRateCurrency] = useState(clientCurrency)
+    const [totalAmount, setTotalAmount] = useState(0)
     const [totalWeeks, setTotalWeeks] = useState(null)
     const [totalHours, setTotalHours] = useState(0)
 
@@ -50,11 +55,38 @@ const RateMaxBudgetForm = (props) => {
     }
 
     const currencyInformation = selectCurrencyInformation({
-        currency: currency
+        currency: rateCurrency
     })
+
+    const renderCurrencies = (currencies) => {
+        return (
+            currencies.map(c => {
+                return (
+                    <MenuItem value={c.name}>
+                        {c.name}
+                    </MenuItem>
+                )
+            })
+        )
+    }
 
     return (
         <Grid container className='RateMaxBudgetForm'>
+            <Grid item xs={6} md={5}>
+                <Box width={1} mt={3}>
+                    <Select
+                        name='Currency'
+                        fullWidth
+                        onChange={(event) => setRateCurrency(event.target.value)}
+                        value={rateCurrency}
+                    >
+                        {renderCurrencies(CURRENCIES)}
+                    </Select>
+                    <FormHelperText>
+                        {`Select currency`}
+                    </FormHelperText>
+                </Box>
+            </Grid>
             <Grid item xs={12}>
                 <Box my={3}>
                     <Grid container spacing={1}>

--- a/src/components/RateProratedMonthlyForm.js
+++ b/src/components/RateProratedMonthlyForm.js
@@ -38,10 +38,12 @@ const RateProratedMonthlyForm = (props) => {
             setCurrency(rateCurrency)
         }
     }, [rateCurrency])
+
     useEffect(() => {
         setTotalWeeks(endDate.diff(startDate, 'days') / 7)
         setCurrentRateInput(currentRate ? currentRate.hourly_rate : 0)
         setMonthlyhoursInput(currentRate ? currentRate.total_expected_hours : 160)
+        setRateCurrency(currentRate ? currentRate.currency : clientCurrency)
     }, [currentRate])
 
     useEffect(() => {

--- a/src/components/RateProratedMonthlyForm.js
+++ b/src/components/RateProratedMonthlyForm.js
@@ -1,10 +1,15 @@
 import React, { useEffect, useState } from 'react'
 import {
     Box,
+    FormHelperText,
     Grid,
+    MenuItem,
+    Select,
     TextField,
     Typography
 } from '@material-ui/core/'
+
+import { CURRENCIES } from '../constants'
 import {
     formatAmount,
     selectCurrencyInformation
@@ -13,19 +18,26 @@ import {
 const RateProratedMonthlyForm = (props) => {
 
     const {
-        currency,
+        clientCurrency,
         currentRate,
         endDate,
         setNewAllocationRate,
+        setCurrency,
         startDate
     } = props
 
-    const [totalAmount, setTotalAmount] = useState(null)
     const [monthlyHoursInput, setMonthlyhoursInput] = useState(null)
     const [currentRateInput, setCurrentRateInput] = useState(null)
+    const [rateCurrency, setRateCurrency] = useState(clientCurrency)
+    const [totalAmount, setTotalAmount] = useState(null)
     const [totalWeeks, setTotalWeeks] = useState(null)
     const [totalHours, setTotalHours] = useState(0)
 
+    useEffect(() => {
+        if (rateCurrency) {
+            setCurrency(rateCurrency)
+        }
+    }, [rateCurrency])
     useEffect(() => {
         setTotalWeeks(endDate.diff(startDate, 'days') / 7)
         setCurrentRateInput(currentRate ? currentRate.hourly_rate : 0)
@@ -55,15 +67,42 @@ const RateProratedMonthlyForm = (props) => {
     }, [startDate, endDate])
 
     const currencyInformation = selectCurrencyInformation({
-        currency: currency ? currency : 'USD'
+        currency: rateCurrency ? rateCurrency : 'USD'
     })
     const paymentAmount = formatAmount({
         amount: totalAmount,
         currencyInformation: currencyInformation
     })
 
+    const renderCurrencies = (currencies) => {
+        return (
+            currencies.map(c => {
+                return (
+                    <MenuItem value={c.name}>
+                        {c.name}
+                    </MenuItem>
+                )
+            })
+        )
+    }
+
     return (
         <Grid container className='RateProratedMonthlyForm'>
+            <Grid item xs={6} md={5}>
+                <Box width={1} mt={3}>
+                    <Select
+                        name='Currency'
+                        fullWidth
+                        onChange={(event) => setRateCurrency(event.target.value)}
+                        value={rateCurrency}
+                    >
+                        {renderCurrencies(CURRENCIES)}
+                    </Select>
+                    <FormHelperText>
+                        {`Select currency`}
+                    </FormHelperText>
+                </Box>
+            </Grid>
             <Grid item xs={12}>
                 <Box my={3}>
                     <Grid container justify='left' spacing={1}>

--- a/src/operations/mutations/RateMutations.js
+++ b/src/operations/mutations/RateMutations.js
@@ -1,12 +1,13 @@
 import { gql } from '@apollo/client'
 
 export const CREATE_RATE = gql`
-    mutation createRate($total_expected_hours: Int, $hourly_rate: String!, $type: String!, $contributor_id: Int!){
+    mutation createRate($total_expected_hours: Int, $hourly_rate: String!, $type: String!,$currency: String, $contributor_id: Int!){
         createRate(createFields: {
             active: true
             total_expected_hours: $total_expected_hours
             hourly_rate: $hourly_rate
             type: $type
+            currency: $currency
             contributor_id: $contributor_id
         }){
             id

--- a/src/operations/queries/AllocationQueries.js
+++ b/src/operations/queries/AllocationQueries.js
@@ -13,6 +13,7 @@ export const GET_ALLOCATIONS = gql`
                 active
                 hourly_rate
                 type
+                currency
                 total_expected_hours
             }
             payment {

--- a/src/operations/queries/ContributorQueries.js
+++ b/src/operations/queries/ContributorQueries.js
@@ -44,6 +44,7 @@ export const GET_CONTRIBUTOR_ALLOCATIONS = gql`
                     active
                     type
                     hourly_rate
+                    currency
                     total_expected_hours
                 }
                 project {


### PR DESCRIPTION
### **Issue #251**

**Description:**

This pr has the necessary implementations to add `currency` into `rates`. This pr has by changes in the DB model, changes in the backend, and changes in the frontend. The extension of this functionality includes adding the `currency` attribute in the DB model and being able to add the currency when creating a new allocation

**Breakdown**

* New migration already run on development/staging database called `addCurrenccyToRates`. This adds a new column `currency` of type `String` to the `Rates` table
* Added `currency` attribute into the `ProjectType`
* I implemented a currency dropdown selector in the `AllocationAddForm` as I did on the create client form.
* Now when creating an allocation by default the currency will be the currency of the client, if there's a past allocation for the contributor the currency will be the currency of the last allocation made to this contributor.
* Added the `currency` attribute to the queries made of the `rate`

**Notice**

Even that now each allocation will have its own currency everything is set to be populated with the currency of the client, this is because I haven't worked yet on the conversion between currencies. This can be done in other pr.

**Proof of implementation**

https://www.loom.com/share/9ad90b6f8a624eef851ca4b4938fdb4b