### PR TITLE
Fixed reate currency

### DIFF
--- a/src/components/AllocationAddForm.js
+++ b/src/components/AllocationAddForm.js
@@ -483,6 +483,7 @@ const AllocationAddForm = (props) => {
                                     <RateProratedMonthlyForm
                                         clientCurrency={clientCurrency}
                                         currentRate={mostRecentAllocation ? mostRecentAllocation.rate : null}
+                                        selectedPayment={selectedPayment}
                                         setNewAllocationRate={setNewAllocationRate}
                                         setCurrency={setRateCurrency}
                                         startDate={moment(startDate)}
@@ -492,6 +493,7 @@ const AllocationAddForm = (props) => {
                                     <RateMaxBudgetForm
                                         clientCurrency={clientCurrency}
                                         currentRate={mostRecentAllocation ? mostRecentAllocation.rate : null}
+                                        selectedPayment={selectedPayment}
                                         setCurrency={setRateCurrency}
                                         setNewAllocationRate={setNewAllocationRate}
                                         startDate={moment(startDate)}

--- a/src/components/AllocationOverview.js
+++ b/src/components/AllocationOverview.js
@@ -56,12 +56,9 @@ const AllocationOverview = (props) => {
     const [getClientPayments, {
         data: dataClientPayments,
         loading: loadingClientPayments,
-        error: errorClientPayments,
-        called
+        error: errorClientPayments
     }] = useLazyQuery(GET_CLIENT_PAYMENTS, {
         onCompleted: dataClientPayments => {
-            console.log('dataClientPayments');
-            console.log(dataClientPayments);
             setClientPayments(dataClientPayments.getClientById)
         }
     })
@@ -119,14 +116,11 @@ const AllocationOverview = (props) => {
 
     useEffect(() => {
         if (contributorAllocation) {
-            console.log('contributorAllocation');
-            console.log(contributorAllocation);
             getClientPayments({
                 variables: {
                     clientId: contributorAllocation.project.client.id
                 }
             })
-            console.log('getContributorRates');
             getContributorRates({
                 variables: {
                     id: contributorAllocation.contributor.id
@@ -146,11 +140,6 @@ const AllocationOverview = (props) => {
     const handleDeleteAllocation = async () => {
         const paymentDeleted = await deleteAllocation()
         onClose()
-    }
-
-    if (called) {
-        console.log('CALLED');
-        console.log(called);
     }
 
     const handleUpdateAllocation = async ({
@@ -212,11 +201,7 @@ const AllocationOverview = (props) => {
     if (errorAllocation || errorClientPayments) return `Error`
 
     const { getAllocationById: allocation } = dataAllocation
-    const payments = [{ id: null, amount: null, date_paid: null }]
-    // console.log('contributorAllocation main');
-    // console.log(contributorAllocation);
-    // console.log('clientPayments');
-    // console.log(clientPayments);
+    const payments = [null]
     if (clientPayments) {
         payments.unshift(...clientPayments.payments)
     }
@@ -224,9 +209,6 @@ const AllocationOverview = (props) => {
     if (!contributorAllocation) {
         setContributorAllocation(allocation)
     }
-
-    console.log('contributorRates');
-    console.log(contributorRates);
 
     return (
         <Dialog

--- a/src/components/AllocationOverview.js
+++ b/src/components/AllocationOverview.js
@@ -47,6 +47,7 @@ const AllocationOverview = (props) => {
         error: errorAllocation,
         loading: loadingAllocation
     } = useQuery(GET_ALLOCATION_INFO, {
+        fetchPolicy: 'cache-and-network',
         variables: {
             id: allocationInfo.id
         }
@@ -55,9 +56,12 @@ const AllocationOverview = (props) => {
     const [getClientPayments, {
         data: dataClientPayments,
         loading: loadingClientPayments,
-        error: errorClientPayments
+        error: errorClientPayments,
+        called
     }] = useLazyQuery(GET_CLIENT_PAYMENTS, {
         onCompleted: dataClientPayments => {
+            console.log('dataClientPayments');
+            console.log(dataClientPayments);
             setClientPayments(dataClientPayments.getClientById)
         }
     })
@@ -115,11 +119,14 @@ const AllocationOverview = (props) => {
 
     useEffect(() => {
         if (contributorAllocation) {
+            console.log('contributorAllocation');
+            console.log(contributorAllocation);
             getClientPayments({
                 variables: {
                     clientId: contributorAllocation.project.client.id
                 }
             })
+            console.log('getContributorRates');
             getContributorRates({
                 variables: {
                     id: contributorAllocation.contributor.id
@@ -131,9 +138,19 @@ const AllocationOverview = (props) => {
         }
     }, [contributorAllocation])
 
+    const handleClose = () => {
+        setContributorAllocation(null)
+        onClose()
+    }
+
     const handleDeleteAllocation = async () => {
         const paymentDeleted = await deleteAllocation()
         onClose()
+    }
+
+    if (called) {
+        console.log('CALLED');
+        console.log(called);
     }
 
     const handleUpdateAllocation = async ({
@@ -197,20 +214,24 @@ const AllocationOverview = (props) => {
     const { getAllocationById: allocation } = dataAllocation
     //const { getClientById: client } = dataClientPayments
     const payments = [{ id: null, amount: null, date_paid: null }]
-    console.log('clientPayments');
-    console.log(clientPayments);
+    // console.log('contributorAllocation main');
+    // console.log(contributorAllocation);
+    // console.log('clientPayments');
+    // console.log(clientPayments);
     if (clientPayments) {
         payments.unshift(...clientPayments.payments)
     }
-    console.log('payments');
-    console.log(payments);
 
     if (!contributorAllocation) {
         setContributorAllocation(allocation)
     }
 
     return (
-        <Dialog className='AllocationOverview' onClose={onClose} open={open}>
+        <Dialog
+            className='AllocationOverview'
+            onClose={() => handleClose()}
+            open={open}
+        >
             <DialogTitle>
                 {`Allocation Detail`}
             </DialogTitle>

--- a/src/components/AllocationOverview.js
+++ b/src/components/AllocationOverview.js
@@ -180,7 +180,7 @@ const AllocationOverview = (props) => {
                 end_date: moment(endDate).format('YYYY-MM-DD'),
                 date_paid: null,
                 rate_id: Number(selectedRate.id),
-                payment_id: payment.id
+                payment_id: payment ? payment.id : null
             }
         })
         if (loadingUpdatedAllocation) return ''
@@ -197,9 +197,13 @@ const AllocationOverview = (props) => {
     const { getAllocationById: allocation } = dataAllocation
     //const { getClientById: client } = dataClientPayments
     const payments = [{ id: null, amount: null, date_paid: null }]
+    console.log('clientPayments');
+    console.log(clientPayments);
     if (clientPayments) {
         payments.unshift(...clientPayments.payments)
     }
+    console.log('payments');
+    console.log(payments);
 
     if (!contributorAllocation) {
         setContributorAllocation(allocation)
@@ -225,6 +229,7 @@ const AllocationOverview = (props) => {
                     currency={allocation.project.client.currency}
                     endDate={updatedAllocationEndDate}
                     rate={allocation.rate}
+                    selectedPayment={updatedAllocationPayment}
                     setEndDate={setUpdatedAllocationEndDate}
                     setNewAllocationRate={setUpdatedAllocationRate}
                     setSelectedCurrency={setSelectedCurrency}

--- a/src/components/AllocationOverview.js
+++ b/src/components/AllocationOverview.js
@@ -178,23 +178,29 @@ const AllocationOverview = (props) => {
             selectedRate.id = newRate.data.createRate.id
         }
         //update allocation with that rate id
-        const updatedAllocation = await updateAllocation({
-            variables: {
-                id: allocation.id,
-                amount: Number(rate.total_amount),
-                start_date: moment(startDate).format('YYYY-MM-DD'),
-                end_date: moment(endDate).format('YYYY-MM-DD'),
-                date_paid: null,
-                rate_id: Number(selectedRate.id),
-                payment_id: payment ? payment.id : null
+        try {
+            const updatedAllocation = await updateAllocation({
+                variables: {
+                    id: allocation.id,
+                    amount: Number(rate.total_amount),
+                    start_date: moment(startDate).format('YYYY-MM-DD'),
+                    end_date: moment(endDate).format('YYYY-MM-DD'),
+                    date_paid: null,
+                    rate_id: Number(selectedRate.id),
+                    payment_id: payment ? payment.id : null
+                }
+            })
+            if (loadingUpdatedAllocation) return ''
+            else if (updatedAllocation.errors) {
+                throw updatedAllocation.errors
+            } else {
+                onClose()
             }
-        })
-        if (loadingUpdatedAllocation) return ''
-        else if (updatedAllocation.errors) {
-            console.log('Error updating the allocation');
-        } else {
+        } catch (error) {
+            console.log(`error ${error}`);
             onClose()
         }
+
     }
 
     if (loadingAllocation || loadingClientPayments) return <LoadingProgress/>

--- a/src/components/ContributorTile.js
+++ b/src/components/ContributorTile.js
@@ -246,7 +246,7 @@ const ContributorTile = (props) => {
                 selectedAllocation &&
                 <AllocationOverview
                     allocationInfo={selectedAllocation}
-                    onClose={() => handleAllocationOverview(false)}
+                    onClose={() => handleAllocationOverview({ value: false })}
                     open={openAllocationOverview}
                 />
             }

--- a/src/components/EditAllocationInfo.js
+++ b/src/components/EditAllocationInfo.js
@@ -36,17 +36,11 @@ const EditAllocationInfo = (props) => {
 
     const [openPayments, setOpenPayments] = useState(false)
 
-    useEffect(() => {
-        if (!selectedPayment) {
-            setSelectedPayment(payments[findIndex(payments, ['amount', allocation.payment])])
-        }
-    })
-
     const handleClickPayments = () => {
         setOpenPayments(!openPayments)
     }
     const onClickPayment = (payment) => {
-        if (payment.id) {
+        if (payment) {
             setSelectedPayment(payment)
         } else {
             setSelectedPayment(null)
@@ -56,12 +50,10 @@ const EditAllocationInfo = (props) => {
 
     const paymentAmount = (
         selectedPayment
-            ? selectedPayment.amount
-                ? formatAmount({
-                    amount: selectedPayment.amount / 100,
-                    currencyInformation: currencyInformation
-                })
-                : 'Proposed'
+            ? formatAmount({
+                amount: selectedPayment.amount / 100,
+                currencyInformation: currencyInformation
+            })
             : 'Proposed'
     )
     const datePaid = (
@@ -76,19 +68,23 @@ const EditAllocationInfo = (props) => {
 
     const listPayments = (payments) => {
         const paymentsList = differenceWith(payments, [selectedPayment], isEqual)
-        return paymentsList.map(p => {
-            const paymentAmount = formatAmount({
-                amount: p.amount / 100,
-                currencyInformation: currencyInformation
-            })
+        return paymentsList.map(payment => {
+            const paymentAmount = (
+                payment
+                    ? (formatAmount({
+                        amount: payment.amount / 100,
+                        currencyInformation: currencyInformation
+                    }))
+                    : null
+            )
             return (
                 <List component='div' disablePadding>
-                    <ListItem button onClick={() => onClickPayment(p)}>
+                    <ListItem button onClick={() => onClickPayment(payment)}>
                         <Grid container>
                             <Grid item xs={6}>
                                 <ListItemText
                                     primary={`${
-                                        p.amount
+                                        payment
                                             ? `${paymentAmount}`
                                             : 'Propose'
                                     }`}
@@ -96,9 +92,11 @@ const EditAllocationInfo = (props) => {
                             </Grid>
                             <Grid item xs={3} align='center'>
                                 <Typography variant='caption' color='secondary'>
-                                    {`${p.date_paid
-                                        ? moment(p.date_paid, 'x').format('MM/DD/YYYY')
-                                        : ''
+                                    {`${payment
+                                        ? payment.date_paid
+                                            ? moment(payment.date_paid, 'x').format('MM/DD/YYYY')
+                                            : 'Not paid yet'
+                                        : 'Proposed'
                                     }`}
                                 </Typography>
                             </Grid>

--- a/src/components/EditAllocationInfo.js
+++ b/src/components/EditAllocationInfo.js
@@ -39,9 +39,10 @@ const EditAllocationInfo = (props) => {
     //const [selectedPayment, setSelectedPayment] = useState(null)
 
     useEffect(() => {
+        console.log('selectedPayment');
+        console.log(selectedPayment);
         if (!selectedPayment) {
             setSelectedPayment(payments[findIndex(payments, ['amount', allocation.payment])])
-
         }
     })
 
@@ -49,7 +50,11 @@ const EditAllocationInfo = (props) => {
         setOpenPayments(!openPayments)
     }
     const onClickPayment = (payment) => {
-        setSelectedPayment(payment)
+        if (payment.id) {
+            setSelectedPayment(payment)
+        } else {
+            setSelectedPayment(null)
+        }
         setOpenPayments(false)
     }
 

--- a/src/components/EditAllocationInfo.js
+++ b/src/components/EditAllocationInfo.js
@@ -39,8 +39,6 @@ const EditAllocationInfo = (props) => {
     //const [selectedPayment, setSelectedPayment] = useState(null)
 
     useEffect(() => {
-        console.log('selectedPayment');
-        console.log(selectedPayment);
         if (!selectedPayment) {
             setSelectedPayment(payments[findIndex(payments, ['amount', allocation.payment])])
         }

--- a/src/components/EditAllocationRate.js
+++ b/src/components/EditAllocationRate.js
@@ -30,6 +30,7 @@ const EditAllocationRate = (props) => {
         //onClose,
 
         endDate,
+        selectedPayment,
         setEndDate,
         setNewAllocationRate,
         setSelectedCurrency,
@@ -61,6 +62,9 @@ const EditAllocationRate = (props) => {
     //const [selectedCurrency, setSelectedCurrency] = useState(null)
     const [selectedRateType, setSelectedRateType] = useState(rate.type)
     //const [startDate, setStartDate] = useState(moment(allocation.start_date, 'x')['_d'])
+
+    // console.log('selectedPayment');
+    // console.log(selectedPayment);
 
     const getRangedTimeEntries = (dates) => {
         const [start, end] = dates
@@ -127,6 +131,7 @@ const EditAllocationRate = (props) => {
                             rateCurrency={rate.currency}
                             clientCurrency={currency}
                             currentRate={rate}
+                            selectedPayment={selectedPayment}
                             setNewAllocationRate={setNewAllocationRate}
                             setCurrency={setSelectedCurrency}
                             startDate={moment(startDate)}
@@ -137,6 +142,7 @@ const EditAllocationRate = (props) => {
                             currentTotal={allocation.amount}
                             clientCurrency={currency}
                             currentRate={rate}
+                            selectedPayment={selectedPayment}
                             setCurrency={setSelectedCurrency}
                             setNewAllocationRate={setNewAllocationRate}
                             startDate={moment(startDate)}

--- a/src/components/RateMaxBudgetForm.js
+++ b/src/components/RateMaxBudgetForm.js
@@ -22,6 +22,7 @@ const RateMaxBudgetForm = (props) => {
         currentTotal,
         createRate,
         endDate,
+        selectedPayment,
         setCurrency,
         setNewAllocationRate,
         startDate
@@ -38,11 +39,18 @@ const RateMaxBudgetForm = (props) => {
             setCurrency(rateCurrency)
         }
     }, [rateCurrency])
+
     useEffect(() => {
         setTotalWeeks(endDate.diff(startDate, 'days') / 7)
         setCurrentRateInput(currentRate ? currentRate.hourly_rate : 0)
         setRateCurrency(currentRate ? currentRate.currency : clientCurrency)
     }, [currentRate])
+
+    useEffect(() => {
+        if (selectedPayment) {
+            setRateCurrency(clientCurrency)
+        }
+    }, [selectedPayment])
 
     useEffect(() => {
         setTotalHours(totalAmount && currentRateInput ? ((totalAmount / 100) / currentRateInput).toFixed(2) : 0)
@@ -86,7 +94,8 @@ const RateMaxBudgetForm = (props) => {
                         name='Currency'
                         fullWidth
                         onChange={(event) => setRateCurrency(event.target.value)}
-                        value={rateCurrency}
+                        value={selectedPayment ? clientCurrency : rateCurrency}
+                        disabled={selectedPayment}
                     >
                         {renderCurrencies(CURRENCIES)}
                     </Select>

--- a/src/components/RateProratedMonthlyForm.js
+++ b/src/components/RateProratedMonthlyForm.js
@@ -95,12 +95,6 @@ const RateProratedMonthlyForm = (props) => {
             })
         )
     }
-    // const changeRate = ({ clientCurrency, rate, selectedPayment }) => {
-    //
-    // }
-
-    console.log('selectedPayment');
-    console.log(selectedPayment);
 
     return (
         <Grid container className='RateProratedMonthlyForm'>

--- a/src/components/RateProratedMonthlyForm.js
+++ b/src/components/RateProratedMonthlyForm.js
@@ -21,6 +21,7 @@ const RateProratedMonthlyForm = (props) => {
         clientCurrency,
         currentRate,
         endDate,
+        selectedPayment,
         setNewAllocationRate,
         setCurrency,
         startDate
@@ -34,18 +35,24 @@ const RateProratedMonthlyForm = (props) => {
     const [totalHours, setTotalHours] = useState(0)
 
     useEffect(() => {
-        if (!rateCurrency) {
-            setRateCurrency(clientCurrency)
-        }
-        setCurrency(rateCurrency)
-    }, [rateCurrency])
-
-    useEffect(() => {
         setTotalWeeks(endDate.diff(startDate, 'days') / 7)
         setCurrentRateInput(currentRate ? currentRate.hourly_rate : 0)
         setMonthlyhoursInput(currentRate ? currentRate.total_expected_hours : 160)
         setRateCurrency(currentRate ? currentRate.currency : clientCurrency)
     }, [currentRate])
+    
+    useEffect(() => {
+        if (selectedPayment) {
+            setRateCurrency(clientCurrency)
+        }
+    }, [selectedPayment])
+
+    useEffect(() => {
+        if (!rateCurrency) {
+            setRateCurrency(clientCurrency)
+        }
+        setCurrency(rateCurrency)
+    }, [rateCurrency])
 
     useEffect(() => {
         setTotalAmount(currentRateInput * monthlyHoursInput)
@@ -88,6 +95,9 @@ const RateProratedMonthlyForm = (props) => {
             })
         )
     }
+    const changeRate = ({ clientCurrency, rate, selectedPayment }) => {
+
+    }
 
     return (
         <Grid container className='RateProratedMonthlyForm'>
@@ -97,7 +107,8 @@ const RateProratedMonthlyForm = (props) => {
                         name='Currency'
                         fullWidth
                         onChange={(event) => setRateCurrency(event.target.value)}
-                        value={rateCurrency}
+                        value={selectedPayment ? clientCurrency : rateCurrency}
+                        disabled={selectedPayment}
                     >
                         {renderCurrencies(CURRENCIES)}
                     </Select>

--- a/src/components/RateProratedMonthlyForm.js
+++ b/src/components/RateProratedMonthlyForm.js
@@ -40,7 +40,7 @@ const RateProratedMonthlyForm = (props) => {
         setMonthlyhoursInput(currentRate ? currentRate.total_expected_hours : 160)
         setRateCurrency(currentRate ? currentRate.currency : clientCurrency)
     }, [currentRate])
-    
+
     useEffect(() => {
         if (selectedPayment) {
             setRateCurrency(clientCurrency)

--- a/src/components/RateProratedMonthlyForm.js
+++ b/src/components/RateProratedMonthlyForm.js
@@ -95,9 +95,12 @@ const RateProratedMonthlyForm = (props) => {
             })
         )
     }
-    const changeRate = ({ clientCurrency, rate, selectedPayment }) => {
+    // const changeRate = ({ clientCurrency, rate, selectedPayment }) => {
+    //
+    // }
 
-    }
+    console.log('selectedPayment');
+    console.log(selectedPayment);
 
     return (
         <Grid container className='RateProratedMonthlyForm'>


### PR DESCRIPTION
### **Issue #345**

**Important**

This branch has the same changes of the pr #343. i recommend reviewing this one first or rebasing this branch.

**Description**

This branch has the implementation of what we discussed last week in a meeting. It consists of the edge case situation where the rate currency is different from the client currency causing problems at the moment of operating with the amount. The workaround for this is to force the rate currency to be the same as the client currency if there's a payment selected, if the allocation is proposed the currency can be different. So the way that I implemented this is disabling the currency selector if there's a payment selected.

**Breakdown**

* This has all the changes of pr #343
* On both `RateProratedMonthlyForm` and `RateMaxBudgetForm` the currency selector gets disabled if there `selectedPayment` variable is not null. 

**Implementation proof**

https://www.loom.com/share/5b021e1c55794008bb770277ece2ebcc