### PR TITLE
Pull requests as metrics and sync Github issues from UI

### DIFF
--- a/api/handlers/github.js
+++ b/api/handlers/github.js
@@ -81,14 +81,9 @@ const github = module.exports = (() => {
         })
     }
 
-    const fetchRepoIssues = async (params) => {
+    const fetchRepoIssues = (params) => {
         const octokit = new Octokit({
             auth: params.auth_key
-        })
-        const res = octokit.paginate(octokit.issues.listForRepo, {
-            owner: params.owner,
-            repo: params.repo,
-            state: 'all'
         })
         return octokit.paginate(octokit.issues.listForRepo, {
             owner: params.owner,

--- a/api/modules/dataSyncs.js
+++ b/api/modules/dataSyncs.js
@@ -153,6 +153,26 @@ const dataSyncs = module.exports = (() => {
         return syncedPermissions
     }
 
+    const syncPullRequests = async (params) => {
+        const pullRequests = []
+        const repoInformation = split(params.github_url, '/')
+        try {
+            const issues = await github.fetchRepoIssues({
+                auth_key: params.auth_key,
+                owner: repoInformation[repoInformation.length - 2],
+                repo: repoInformation[repoInformation.length - 1]
+            })
+            issues.map(i => {
+                if (i.pull_request) {
+                    pullRequests.push(i)
+                }
+            })
+        } catch (error) {
+            console.log('error: ' + error);
+        }
+        return pullRequests
+    }
+
     const syncTogglProject = async (params) => {
         try {
             const timeEntries = await toggl.fetchWorkspaceTimeEntries({
@@ -166,7 +186,7 @@ const dataSyncs = module.exports = (() => {
                 project_id: params.project_id
             })
         } catch (error) {
-            console.log('error: ' + error);
+            console.log('error: ' + error)
             return
         }
         return true
@@ -177,6 +197,7 @@ const dataSyncs = module.exports = (() => {
         syncGithubIssues,
         syncInvoicelyCSV,
         syncProjectCollaboratorsPermission,
+        syncPullRequests,
         syncTogglProject
     }
 })()

--- a/api/modules/dataSyncs.js
+++ b/api/modules/dataSyncs.js
@@ -64,7 +64,7 @@ const dataSyncs = module.exports = (() => {
         })
         await Promise.all(
             issues.map(async i => {
-                const matchingIssue = await findIssueByGithubUrl(i.url)
+                const matchingIssue = await findIssueByGithubUrl(i.html_url)
                 if (!matchingIssue) {
                     await db.models.Issue.create({
                         github_url: i.html_url,

--- a/api/modules/dataSyncs.js
+++ b/api/modules/dataSyncs.js
@@ -57,11 +57,21 @@ const dataSyncs = module.exports = (() => {
     const syncGithubIssues = async (params) => {
         const newIssues = []
         const repoInformation = split(params.github_url, '/')
-        const issues = await github.fetchRepoIssues({
-            auth_key: params.auth_key,
-            owner: repoInformation[repoInformation.length - 2],
-            repo: repoInformation[repoInformation.length - 1]
-        })
+        const issues = []
+        try {
+            const githubIssues = await github.fetchRepoIssues({
+                auth_key: params.auth_key,
+                owner: repoInformation[repoInformation.length - 2],
+                repo: repoInformation[repoInformation.length - 1]
+            })
+            githubIssues.map(i => {
+                if (!i.pull_request) {
+                    issues.push(i)
+                }
+            })
+        } catch (error) {
+            console.log('error: ' + error);
+        }
         await Promise.all(
             issues.map(async i => {
                 const matchingIssue = await findIssueByGithubUrl(i.html_url)

--- a/api/schema/resolvers/ProjectResolver.js
+++ b/api/schema/resolvers/ProjectResolver.js
@@ -581,12 +581,17 @@ module.exports = {
                 contributors: projectContributors
             })
         },
-        syncProjectIssues: async (root, args, { models }) => {
+        syncProjectIssues: async (root, args, { cookies, models }) => {
             const project = await models.Project.findByPk(args.project_id)
+            const contributor = await models.Contributor.findByPk(
+                cookies.userSession
+                    ? cookies.userSession
+                    : args.contributor_id
+            )
             const syncedIssues = await apiModules.dataSyncs.syncGithubIssues({
                 project_id: args.project_id,
                 github_url: project.github_url,
-                auth_key: args.github_personal_key
+                auth_key: contributor.github_access_token
             })
             await models.Project.update({
                 date_last_synced: moment.utc()

--- a/api/schema/types/ProjectType.js
+++ b/api/schema/types/ProjectType.js
@@ -34,6 +34,16 @@ module.exports = gql`
             toDate:String,
             githubPersonalKey: String
         ): Int
+        githubPullRequestsClosed(
+            fromDate: String,
+            toDate: String,
+            contributorId: Int
+        ): Int
+        githubPullRequestsOpened(
+            fromDate: String,
+            toDate: String,
+            contributorId: Int
+        ): Int
         timeEntries(
             fromDate: String
             toDate: String

--- a/api/schema/types/ProjectType.js
+++ b/api/schema/types/ProjectType.js
@@ -125,7 +125,7 @@ module.exports = gql`
         ): [Contributor]
         syncProjectIssues(
             project_id: Int!,
-            github_personal_key: String
+            contributor_id: Int
         ): [Issue]
         syncTogglProject(
             project_id: Int!

--- a/api/tests/github.js
+++ b/api/tests/github.js
@@ -49,7 +49,7 @@ console.log('github');
 //     })
 
 const issues = github.fetchRepoIssues({
-    auth_key: '5d43fb2bb7be3c47e53c48756d2fd8055b51a121',
+    auth_key: '',
     repo: 'project-trinary',
     owner: 'setlife-network'
 })

--- a/src/components/IssueTile.js
+++ b/src/components/IssueTile.js
@@ -18,7 +18,8 @@ const IssueTile = (props) => {
             borderRadius='borderRadius'
             border={1}
             borderColor='secondary.light'
-            p={3}
+            px={3}
+            py={1}
             my={3}
         >
             <Grid container>
@@ -32,12 +33,9 @@ const IssueTile = (props) => {
                         <Typography variant='h6' noWrap>
                             {issue.name}
                         </Typography>
-                        <Typography color='secondary'>
-                            {`Issue # ${issue.github_number}`}
-                        </Typography>
                     </Box>
                 </Grid>
-                <Grid item lg={2}>
+                <Grid item xs={4} lg={2}>
                     <Box
                         bgcolor={`${issueIsOpen ? 'primary.main' : 'primary.light_blue'}`}
                         borderRadius='borderRadius'
@@ -50,6 +48,20 @@ const IssueTile = (props) => {
                         </Typography>
                     </Box>
                 </Grid>
+                <Grid xs={12}/>
+                <Grid item xs={6} mt={1} align='left'>
+                    <Typography color='secondary'>
+                        {`Issue # ${issue.github_number}`}
+                    </Typography>
+                </Grid>
+                <Grid item xs={6} mt={1} align='right'>
+                    <Box>
+                        <Typography color='secondary'>
+                            {`${moment(issue.date_opened, ['x']).format('MM/DD/YYYY')}`}
+                        </Typography>
+                    </Box>
+                </Grid>
+
                 <Grid item xs={12} align='left'/>
                 <Grid item xs={6}>
                     <Box mt={2}>
@@ -71,13 +83,6 @@ const IssueTile = (props) => {
                                 </Grid>
                             </Grid>
                         </a>
-                    </Box>
-                </Grid>
-                <Grid item xs={6} align='right'>
-                    <Box mt={2}>
-                        <Typography color='secondary'>
-                            {`${moment(issue.date_opened, ['x']).format('MM/DD/YYYY')}`}
-                        </Typography>
                     </Box>
                 </Grid>
             </Grid>

--- a/src/components/IssueTile.js
+++ b/src/components/IssueTile.js
@@ -16,7 +16,8 @@ const IssueTile = (props) => {
         <Box
             className='IssueTile'
             borderRadius='borderRadius'
-            boxShadow={3}
+            border={1}
+            borderColor='secondary.light'
             p={3}
             my={3}
         >
@@ -49,9 +50,7 @@ const IssueTile = (props) => {
                         </Typography>
                     </Box>
                 </Grid>
-                <Grid item xs={12} align='left'>
-
-                </Grid>
+                <Grid item xs={12} align='left'/>
                 <Grid item xs={6}>
                     <Box mt={2}>
                         <a

--- a/src/components/ProjectIssues.js
+++ b/src/components/ProjectIssues.js
@@ -1,7 +1,8 @@
 import React, { useState } from 'react'
-import { useQuery } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client'
 import {
     Box,
+    Button,
     Grid
 } from '@material-ui/core'
 import moment from 'moment'
@@ -13,6 +14,7 @@ import LoadingProgress from './LoadingProgress'
 import ProjectIssuesMetrics from './ProjectIssuesMetrics'
 
 import { GET_PROJECT_ISSUES } from '../operations/queries/ProjectQueries'
+import { SYNC_GITHUB_ISSUES } from '../operations/mutations/ProjectMutations'
 import { pageName } from '../reactivities/variables'
 
 const ProjectIssues = (props) => {
@@ -29,6 +31,27 @@ const ProjectIssues = (props) => {
         variables: {
             id: Number(projectId)
         }
+    })
+
+    const [
+        getIssues,
+        {
+            data: dataIssues,
+            loading: loadingIssues,
+            error: errorIssues
+        }
+    ] = useMutation(SYNC_GITHUB_ISSUES, {
+        variables: {
+            project_id: Number(projectId)
+        },
+        refetchQueries: [
+            {
+                query: GET_PROJECT_ISSUES,
+                variables: {
+                    id: Number(projectId)
+                }
+            }
+        ]
     })
 
     const renderIssues = (issues) => {
@@ -72,12 +95,25 @@ const ProjectIssues = (props) => {
                     closedPullRequests={project.githubPullRequestsClosed}
                 />
             </Grid>
+            <Grid item xs={4} align='left'>
+                <Box mt={3}>
+                    <Button
+                        variant='outlined'
+                        color='primary'
+                        onClick={() => getIssues()}
+                    >
+                        {`Sync last 30 days issues`}
+                    </Button>
+                </Box>
+            </Grid>
             <Grid item xs={12}>
+                {loadingIssues &&
+                    <LoadingProgress/>
+                }
                 <Grid container>
                     {renderIssues(sortedIssues)}
                 </Grid>
-                <Box my={5}>
-                </Box>
+                <Box my={5}/>
             </Grid>
         </Grid>
     )

--- a/src/components/ProjectIssues.js
+++ b/src/components/ProjectIssues.js
@@ -58,6 +58,7 @@ const ProjectIssues = (props) => {
         }
     })
     const sortedIssues = orderBy(last30DayIssues, ['date_closed'], ['desc'])
+    const openPullRequests = project.githubPullRequestsOpened - project.githubPullRequestsClosed
 
     return (
         <Grid container className='ProjectIssues'>
@@ -67,6 +68,8 @@ const ProjectIssues = (props) => {
                     githubURL={project.github_url}
                     openedIssues={project.githubIssuesOpened}
                     closedIssues={project.githubIssuesClosed}
+                    openPullRequests={openPullRequests}
+                    closedPullRequests={project.githubPullRequestsClosed}
                 />
             </Grid>
             <Grid item xs={12}>

--- a/src/components/ProjectIssues.js
+++ b/src/components/ProjectIssues.js
@@ -85,7 +85,7 @@ const ProjectIssues = (props) => {
 
     return (
         <Grid container className='ProjectIssues'>
-            <h1>Issues</h1>
+            <h1>{`Issues`}</h1>
             <Grid item xs={12}>
                 <ProjectIssuesMetrics
                     githubURL={project.github_url}
@@ -95,7 +95,7 @@ const ProjectIssues = (props) => {
                     closedPullRequests={project.githubPullRequestsClosed}
                 />
             </Grid>
-            <Grid item xs={4} align='left'>
+            <Grid item xs={6} sm={4} align='left'>
                 <Box mt={3}>
                     <Button
                         variant='outlined'

--- a/src/components/ProjectIssuesMetrics.js
+++ b/src/components/ProjectIssuesMetrics.js
@@ -23,6 +23,7 @@ const ProjectIssuesMetrics = (props) => {
             align='left'
             borderRadius='borderRadius'
             p={3}
+            boxShadow={3}
         >
 
             <Grid container>

--- a/src/components/ProjectIssuesMetrics.js
+++ b/src/components/ProjectIssuesMetrics.js
@@ -52,7 +52,6 @@ const ProjectIssuesMetrics = (props) => {
                                 <ArrowForwardIcon/>
                             </Typography>
                         </Grid>
-
                     </Grid>
                 </a>
             </Box>

--- a/src/components/ProjectIssuesMetrics.js
+++ b/src/components/ProjectIssuesMetrics.js
@@ -11,7 +11,9 @@ const ProjectIssuesMetrics = (props) => {
     const {
         githubURL,
         openedIssues,
-        closedIssues
+        closedIssues,
+        openPullRequests,
+        closedPullRequests
     } = props
 
     return (
@@ -22,16 +24,42 @@ const ProjectIssuesMetrics = (props) => {
             borderRadius='borderRadius'
             p={3}
         >
-            <Typography>
-                <strong>
-                    {`${openedIssues} active ${openedIssues == 1 ? 'issue' : 'issues'}`}
-                </strong>
-            </Typography>
-            <Typography>
-                <strong>
-                    {`${closedIssues} closed ${closedIssues == 1 ? 'issue' : 'issues'}`}
-                </strong>
-            </Typography>
+
+            <Grid container>
+                <Grid item xs={12} sm={6}>
+                    <Box my={2}>
+                        <Typography color='primary' variant='h5'>
+                            <strong>
+                                {`Issues`}
+                            </strong>
+                        </Typography>
+                        <Typography>
+                            <strong>
+                                {`${openedIssues} active ${openedIssues == 1 ? 'issue' : 'issues'}`}
+                                <br/>
+                                {`${closedIssues} closed ${closedIssues == 1 ? 'issue' : 'issues'}`}
+                            </strong>
+                        </Typography>
+                    </Box>
+                </Grid>
+                <Grid item sm={6}>
+                    <Box my={2}>
+                        <Typography color='primary' variant='h5'>
+                            <strong>
+                                {`Pull Requests`}
+                            </strong>
+                        </Typography>
+                        <Typography>
+                            <strong>
+                                {`${openPullRequests} open pull ${openPullRequests == 1 ? 'request' : 'requests'}`}
+                                <br/>
+                                {`${closedPullRequests} closed pull ${closedPullRequests == 1 ? 'request' : 'requests'}`}
+                            </strong>
+                        </Typography>
+                    </Box>
+                </Grid>
+            </Grid>
+
             <Box mt={2}>
                 <a
                     href={`${githubURL}/issues`}

--- a/src/components/ProjectIssuesMetrics.js
+++ b/src/components/ProjectIssuesMetrics.js
@@ -35,9 +35,9 @@ const ProjectIssuesMetrics = (props) => {
                         </Typography>
                         <Typography>
                             <strong>
-                                {`${openedIssues} active ${openedIssues == 1 ? 'issue' : 'issues'}`}
+                                {`${openedIssues} active`}
                                 <br/>
-                                {`${closedIssues} closed ${closedIssues == 1 ? 'issue' : 'issues'}`}
+                                {`${closedIssues} closed`}
                             </strong>
                         </Typography>
                     </Box>
@@ -51,9 +51,9 @@ const ProjectIssuesMetrics = (props) => {
                         </Typography>
                         <Typography>
                             <strong>
-                                {`${openPullRequests} open pull ${openPullRequests == 1 ? 'request' : 'requests'}`}
+                                {`${openPullRequests} open`}
                                 <br/>
-                                {`${closedPullRequests} closed pull ${closedPullRequests == 1 ? 'request' : 'requests'}`}
+                                {`${closedPullRequests} closed`}
                             </strong>
                         </Typography>
                     </Box>
@@ -69,7 +69,7 @@ const ProjectIssuesMetrics = (props) => {
                         <Grid item>
                             <Typography color='primary'>
                                 <strong>
-                                    Go to issues on Github
+                                    {`GitHub`}
                                 </strong>
                             </Typography>
                         </Grid>

--- a/src/components/ProjectIssuesMetrics.js
+++ b/src/components/ProjectIssuesMetrics.js
@@ -25,7 +25,6 @@ const ProjectIssuesMetrics = (props) => {
             p={3}
             boxShadow={3}
         >
-
             <Grid container>
                 <Grid item xs={12} sm={6}>
                     <Box my={2}>
@@ -60,7 +59,6 @@ const ProjectIssuesMetrics = (props) => {
                     </Box>
                 </Grid>
             </Grid>
-
             <Box mt={2}>
                 <a
                     href={`${githubURL}/issues`}
@@ -74,7 +72,6 @@ const ProjectIssuesMetrics = (props) => {
                                     Go to issues on Github
                                 </strong>
                             </Typography>
-
                         </Grid>
                         <Grid item>
                             <Typography color='primary'>

--- a/src/components/ProjectIssuesMetrics.js
+++ b/src/components/ProjectIssuesMetrics.js
@@ -27,7 +27,7 @@ const ProjectIssuesMetrics = (props) => {
         >
             <Grid container>
                 <Grid item xs={12} sm={6}>
-                    <Box my={2}>
+                    <Box mb={2}>
                         <Typography color='primary' variant='h5'>
                             <strong>
                                 {`Issues`}
@@ -43,7 +43,7 @@ const ProjectIssuesMetrics = (props) => {
                     </Box>
                 </Grid>
                 <Grid item sm={6}>
-                    <Box my={2}>
+                    <Box mb={2}>
                         <Typography color='primary' variant='h5'>
                             <strong>
                                 {`Pull Requests`}

--- a/src/operations/mutations/ProjectMutations.js
+++ b/src/operations/mutations/ProjectMutations.js
@@ -18,6 +18,25 @@ export const ADD_PROJECT = gql`
     }
 `
 
+export const SYNC_GITHUB_ISSUES = gql`
+    mutation syncGithubIssues($project_id: Int!) {
+        syncProjectIssues(project_id: $project_id) {
+            id
+        }
+    }
+`
+
+export const SYNC_PROJECT_GITHUB_CONTRIBUTORS = gql`
+    mutation syncProjectGithubContributors($project_id: Int!, $github_personal_key: String){
+        syncProjectGithubContributors(project_id: $project_id, github_personal_key: $github_personal_key) {
+            id
+            name
+            github_id
+            github_handle
+        }
+    }
+ `
+
 export const UPDATE_PROJECT = gql`
     mutation updateProjectById($project_id: Int!, $date: String!, $expected_budget:Int!, $name: String!, $github_url: String, $expected_budget_timeframe: String, $toggl_url: String){
         updateProjectById(
@@ -41,14 +60,3 @@ export const UPDATE_PROJECT = gql`
         }
     }
 `
-
-export const SYNC_PROJECT_GITHUB_CONTRIBUTORS = gql`
-    mutation syncProjectGithubContributors($project_id: Int!, $github_personal_key: String){
-        syncProjectGithubContributors(project_id: $project_id, github_personal_key: $github_personal_key) {
-            id
-            name
-            github_id
-            github_handle
-        }
-    }
- `

--- a/src/operations/queries/ProjectQueries.js
+++ b/src/operations/queries/ProjectQueries.js
@@ -153,6 +153,8 @@ export const GET_PROJECT_ISSUES = gql`
                 fromDate: $issuesFromDate,
                 toDate: $issuesToDate
             )
+            githubPullRequestsOpened
+            githubPullRequestsClosed
         }
     }
 `


### PR DESCRIPTION
### **Issue #291 #359 #360**

**Description**

This pr resolves multiples issues listed above, the principal one was to add some metrics about the open and closed pull request on GitHub, like the metrics of the issues, for making this I had to make frontend and backend changes, both in this pr. Besides that, I fixed the bugs described in #359 and #360 

**Breakdown**

#291
* The `syncPullRequests ` function on the `dataSyncs` file, since Github returns the pull requests as issues I make use of the GitHub handler function `fetchRepoIssues ` to get all the issues and then I filter the pull requests.
* The `githubPullRequestsClosed` and `githubPullRequestsOpened` are attributes on the Contributor type that returns an integer, both accept as parameters `start date` and `end date`, but it's optional. On the contributor, I added the code to resolve these two attributes/functions
* On the `ProjectQueries` I add these two new attributes and I display them inside the `ProjectIssuesMetrics` component
* I created a button on the `ProjectIssues` component to be able to run the mutation `syncProjectIssues`  from the UI instead of having to make this sync from the apollo console
* The mutation `SYNC_GITHUB_ISSUES` called on the `ProjectIssues` component and declared on the `ProjectMutations`

#359 
* I fixed this bug inside the `syncGithubIssues` function on the `dataSyncs.js` file passing the right attribute `html_url` to the `findIssueByGithubUrl` function, instead of passing the `URL attribute. This is what was causing the bug.

#360 
* As I mentioned before GitHub takes the pull requests as issues, so the problem was that I wasn't filtering the pull request on the `syncGithubIssues` function causing that the pull requests were also being stored on the DB. On another pr, we could store both issues and PR's making a small change to the DB to differentiate them if we think it's convenient.
* To fix this I map the issues returned by the GitHub function `fetchRepoIssues` and store in a separate array all the issues that don't have the `pull_request` attribute

**Proof of implementation**

https://www.loom.com/share/e62d35a5818b40ea997b7438676ff593

<img width="1440" alt="Screen Shot 2021-03-10 at 9 17 20 AM" src="https://user-images.githubusercontent.com/49292858/110670473-ce8e0b80-81a3-11eb-9dee-5aa84db220ea.png">
<img width="1440" alt="Screen Shot 2021-03-10 at 9 18 12 AM" src="https://user-images.githubusercontent.com/49292858/110670484-d0f06580-81a3-11eb-8d51-efc48daab070.png">

**Additional note**
The API key that shows as deleted on one of the tests files is an old key don't worry about it being on the source control
