### PR TITLE
Project Permissions at login

### DIFF
--- a/api/config/constants.js
+++ b/api/config/constants.js
@@ -6,5 +6,27 @@ module.exports = {
     SITE_ROOT: process.env.NODE_ENV == 'production'
         ? process.env.SITE_URL
         : 'http://localhost:6002',
-    USER_AGENT: `${process.env.USER_AGENT}`
+    USER_AGENT: `${process.env.USER_AGENT}`,
+    GITHUB_PERMISSIONS: [
+        {
+            github_permission_level: 'read',
+            project_permission_level: 'read'
+        },
+        {
+            github_permission_level: 'triage',
+            project_permission_level: 'read'
+        },
+        {
+            github_permission_level: 'write',
+            project_permission_level: 'write'
+        },
+        {
+            github_permission_level: 'maintain',
+            project_permission_level: 'write'
+        },
+        {
+            github_permission_level: 'admin',
+            project_permission_level: 'write'
+        },
+    ]
 }

--- a/api/modules/authentication.js
+++ b/api/modules/authentication.js
@@ -1,6 +1,6 @@
 const { split } = require('lodash')
 
-const { fetchAuthUserData } = require('../handlers/github')
+const { fetchAuthUserData, fetchUserPermission } = require('../handlers/github')
 const db = require('../models')
 
 const authentication = module.exports = (() => {

--- a/api/modules/authentication.js
+++ b/api/modules/authentication.js
@@ -30,7 +30,7 @@ const authentication = module.exports = (() => {
         }
     }
 
-    const giveProjectPermissions = async ({ contributor, githubContributor }) => {
+    const grantProjectPermissions = async ({ contributor, githubContributor }) => {
         const projects = await db.models.Project.findAll({
             raw: true
         })
@@ -56,7 +56,7 @@ const authentication = module.exports = (() => {
     return {
         createContributor,
         getContributor,
-        giveProjectPermissions,
+        grantProjectPermissions,
         updateGithubAccessTokenContributor
     }
 

--- a/api/modules/authentication.js
+++ b/api/modules/authentication.js
@@ -1,9 +1,21 @@
 const { split } = require('lodash')
 
 const { fetchAuthUserData, fetchUserPermission } = require('../handlers/github')
+const { handleContributorPermission } = require('../scripts/githubPermissions')
 const db = require('../models')
 
 const authentication = module.exports = (() => {
+
+    const createContributor = async (githubContributor) => {
+        const githubContributorInfo = split(githubContributor.githubUrl, '/')
+        const githubContributorUsername = githubContributorInfo[githubContributorInfo.length - 1]
+        return db.models.Contributor.create({
+            name: githubContributor.name ? githubContributor.name : githubContributorUsername,
+            github_id: githubContributor.id,
+            github_handle: githubContributor.githubUrl,
+            github_access_token: githubContributor.accessToken
+        })
+    }
 
     const getContributor = async ({ githubAccessToken }) => {
         const githubContributor = await fetchAuthUserData({ auth_key: githubAccessToken })
@@ -18,14 +30,16 @@ const authentication = module.exports = (() => {
         }
     }
 
-    const createContributor = async (githubContributor) => {
-        const githubContributorInfo = split(githubContributor.githubUrl, '/')
-        const githubContributorUsername = githubContributorInfo[githubContributorInfo.length - 1]
-        return db.models.Contributor.create({
-            name: githubContributor.name ? githubContributor.name : githubContributorUsername,
-            github_id: githubContributor.id,
-            github_handle: githubContributor.githubUrl,
-            github_access_token: githubContributor.accessToken
+    const giveProjectPermissions = async ({ contributor, githubContributor }) => {
+        const projects = await db.models.Project.findAll({
+            raw: true
+        })
+        projects.map(async p => {
+            await handleContributorPermission({
+                contributor: contributor,
+                githubContributor: githubContributor,
+                project: p,
+            })
         })
     }
 
@@ -42,6 +56,7 @@ const authentication = module.exports = (() => {
     return {
         createContributor,
         getContributor,
+        giveProjectPermissions,
         updateGithubAccessTokenContributor
     }
 

--- a/api/scripts/githubPermissions.js
+++ b/api/scripts/githubPermissions.js
@@ -1,0 +1,83 @@
+const { findIndex } = require('lodash')
+
+import { GITHUB_PERMISSIONS } from '../config/constants'
+
+module.exports(() => {
+
+    const createPermission = async ({ contributor, githubPermission, project }) => {
+        // const permission = GITHUB_PERMISSIONS.map(p => {
+        //     if (githubPermission == p.github_permission_level) {
+        //         return p.project_permission_level
+        //     }
+        // })
+        const permissionIndex = findIndex(GITHUB_PERMISSIONS, ['github_permission_level', githubPermission])
+        const permission = GITHUB_PERMISSIONS[permissionIndex].project_permission_level
+        return db.models.Permission.create({
+            type: permission,
+            contributor_id: contributor.id,
+            project_id: project.id
+        })
+    }
+
+    const handleContributorPermission = async ({ contributor, githubContributor, project }) => {
+        const repoInfo = split(project.github_url, '/')
+        const contributorInfo = split(contributor.github_handle, '/')
+        const githubContributorPermission = await fetchUserPermission({
+            auth_key: contributor.github_access_token,
+            owner: repo[repo.length - 2],
+            repo: repo[repo.length - 1],
+            username: contributorInfo[contributorInfo.lenth - 1]
+        })
+        const contributorPermission = await db.models.Permission.findOne({
+            where: {
+                project_id: project.id,
+                contributor_id: contributor.id
+            }
+        })
+        //could happen three things:
+        //1. the first contributor login so it doesent have permissions
+        //2. the contributor has the permission but is outdated
+        //3. the contributor has the correct permission stored on the db
+        if (!contributorPermission) {
+            createPermission({
+                contributor: contributor,
+                permission: githubContributorPermission,
+                project: project
+            })
+        } else if (contributorPermission) {
+            //check if it's correct or needs to be updated
+
+            // GITHUB_PERMISSIONS.map(p => {
+            //     if (githubContributorPermission == p.github_permission_level) {
+            //         return p.project_permission_level
+            //     }
+            // })
+
+            const githubPermissionIndex = findIndex(GITHUB_PERMISSIONS, ['github_permission_level', githubContributorPermission])
+            if ((GITHUB_PERMISSIONS[githubPermissionIndex].project_permission_level).toUpperCase() != contributorPermission.toUpperCase()) {
+                //the permission level needs to be updated
+                await updatePermission({
+                    contributorId: contributor.id,
+                    projectId: project.id,
+                    permission: (GITHUB_PERMISSIONS[githubPermissionIndex].project_permission_level).toLowerCase()
+                })
+            }
+            //at this point the permission had been created, updated or correct
+        }
+    }
+
+    const updatePermission = async ({ contributorId, projectId, permission }) => {
+        const contributorProjectPermission = await db.models.Permissions.findOne({
+            where: {
+                contributr_id: contributorId,
+                project_id: projectId
+            }
+        })
+        contributorProjectPermission.type = permission
+        return contributorProjectPermission.save()
+    }
+
+    return {
+        handleContributorPermission
+    }
+})();

--- a/api/tests/github.js
+++ b/api/tests/github.js
@@ -48,32 +48,32 @@ console.log('github');
 //         console.log(err);
 //     })
 
-const issues = github.fetchRepoIssues({
-    auth_key: '5d43fb2bb7be3c47e53c48756d2fd8055b51a121',
-    repo: 'project-trinary',
-    owner: 'setlife-network'
-})
-    .then(res => {
-        console.log('res');
-        console.log(res);
-        return res
-    })
-    .catch(err => {
-        console.log('err');
-        console.log(err);
-    })
-
-// const userPermission = github.fetchUserPermission({
+// const issues = github.fetchRepoIssues({
 //     auth_key: '',
-//     owner: 'setlife-network',
 //     repo: 'project-trinary',
-//     username: 'sofiarm21'
+//     owner: 'setlife-network'
 // })
 //     .then(res => {
 //         console.log('res');
 //         console.log(res);
+//         return res
 //     })
 //     .catch(err => {
 //         console.log('err');
 //         console.log(err);
 //     })
+
+const userPermission = github.fetchUserPermission({
+    auth_key: '',
+    owner: 'setlife-network',
+    repo: 'project-trinary',
+    username: 'sofiarm21'
+})
+    .then(res => {
+        console.log('res');
+        console.log(res);
+    })
+    .catch(err => {
+        console.log('err');
+        console.log(err);
+    })

--- a/server.js
+++ b/server.js
@@ -88,6 +88,14 @@ app.get('/api/oauth-redirect', (req, res) => { //redirects to the url configured
             }
             //store contributor id in the cookie session
             req.session.userSession = contributorInfo.contributor.id
+            return contributorInfo
+        })
+        .then((contributorInfo) => {
+            //sync the permissions for the contributor
+            apiModules.authentication.giveProjectPermissions({
+                contributor: contributorInfo.contributor.dataValues,
+                githubContributor: contributorInfo.githubContributor
+            })
         })
         .then(() => {
             res.redirect(SITE_ROOT)

--- a/server.js
+++ b/server.js
@@ -92,7 +92,7 @@ app.get('/api/oauth-redirect', (req, res) => { //redirects to the url configured
         })
         .then((contributorInfo) => {
             //sync the permissions for the contributor
-            apiModules.authentication.giveProjectPermissions({
+            apiModules.authentication.grantProjectPermissions({
                 contributor: contributorInfo.contributor.dataValues,
                 githubContributor: contributorInfo.githubContributor
             })

--- a/src/components/Authentication.js
+++ b/src/components/Authentication.js
@@ -19,9 +19,9 @@ const Authentication = () => {
             }
         }
     }, [data])
-  
+
     if (loading) return <LoadingProgress/>
-      
+
     if (error) return `Error! ${error.message}`
     return (
         <>


### PR DESCRIPTION
### **Issue #335**

**Description:**

This pr contains the implementation described on issue #335, when the user logs in we run a script that adds in the `Permissions` table the access level for a contributor, this access level could be `read` or `write` depending on the GitHub repo access level, if the doesn't exists a permission between a contributor and a project that means that the contributor it's not added to the corresponding GitHub repo

**Breakdown**

* The `GITHUB_PERMISSIONS` constants has the map of the possible GitHub permissions with the trinary permission that corresponds, I added it into the `config/constants` file, this way it can be expansible if we want to tweak the permissions in the future 
* The `giveProjectPermissions` function on the `authentication` file it's the function that gets triggered from the server when the user logs in, it queries all the projects from the database and one by one goes checking the permission.
* I created a new scripts file called `githubPermissions` that contains all its related functions
* The main function is `handleContributorPermission` that does all the logic described here https://github.com/setlife-network/trinary/issues/355#issuecomment-798479775 calling the atomic function that does the work.  The behavior of the function is described in the code with comments.
* The whole process gets called on the server at '/api/oauth-redirect' calling the `giveProjectPermissions` function

**Notes:**

I have only tested this myself, and I only have access to repos with a `write` permission, so I haven't tested what happens if I have a `read` or `triage` permission. 

Don't worry about the keys exposed on the test file, I already changed them

**Implementation proof**

https://www.loom.com/share/280cd050b68e42c993df82c7dde40b51