### PR TITLE
Restricted access to clients by client_id (permissions table)

### DIFF
--- a/api/migrations/20210329164216-addClientIdToPermissionsAndModifyProjectIdColumn.js
+++ b/api/migrations/20210329164216-addClientIdToPermissionsAndModifyProjectIdColumn.js
@@ -1,0 +1,29 @@
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        return queryInterface.sequelize.transaction(t => {
+            return Promise.all([
+                queryInterface.addColumn('Permissions', 'client_id', {
+                    type: Sequelize.DataTypes.INTEGER,
+                    references: {
+                        model: 'Clients',
+                        key: 'id'
+                    }
+                }, { transaction: t }),
+                queryInterface.changeColumn('Permissions', 'project_id', {
+                    allowNull: true
+                }, { transaction: t })
+            ])
+        })
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        return queryInterface.sequelize.transaction(t => {
+            return Promise.all([
+                queryInterface.removeColumn('Permissions', 'client_id', { transaction: t }),
+                queryInterface.changeColumn('resources', 'resourceId', {
+                    allowNull: false
+                }, { transaction: t })
+            ])
+        })
+    }
+};

--- a/api/models/Permission.js
+++ b/api/models/Permission.js
@@ -17,9 +17,15 @@ module.exports = (sequelize) => {
                 key: 'id',
             }
         },
+        client_id: {
+            type: DataTypes.INTEGER,
+            references: {
+                model: 'Clients',
+                key: 'id'
+            }
+        },
         project_id: {
             type: DataTypes.INTEGER,
-            allowNull: false,
             references: {
                 model: 'Projects',
                 key: 'id',

--- a/api/models/index.js
+++ b/api/models/index.js
@@ -57,6 +57,7 @@ const associations = ({ Allocation, Client, Contributor, Issue, Payment, Permiss
     Payment.hasMany(Allocation, { foreignKey: 'payment_id' })
     Project.hasMany(Allocation, { foreignKey: 'project_id' })
     Client.hasMany(Project, { foreignKey: 'client_id' })
+    Client.hasMany(Permission, { foreignKey: 'client_id' })
     Project.hasMany(Permission, { foreignKey: 'project_id' })
     Issue.belongsTo(Project, { foreignKey: 'project_id' })
     Rate.hasMany(Allocation, { foreignKey: 'rate_id' })

--- a/api/schema/resolvers/ClientResolver.js
+++ b/api/schema/resolvers/ClientResolver.js
@@ -53,11 +53,12 @@ module.exports = {
     Mutation: {
         createClient: async (root, { createFields }, { cookies, models }) => {
             try {
+                if (!cookies.userSession || createFields.contributor_id) {
+                    throw new Error('A contributor id is required');
+                }
                 const newlyCreatedClient = await models.Client.create({
                     ...createFields
                 })
-                console.log('createFields');
-                console.log(createFields);
                 const contributor = (
                     await models.Contributor.findByPk(
                         cookies ? cookies.userSession : createFields.contributor_id

--- a/api/schema/resolvers/ClientResolver.js
+++ b/api/schema/resolvers/ClientResolver.js
@@ -55,7 +55,7 @@ module.exports = {
             })
             const contributor = (
                 await models.Contributor.findByPk(
-                    cookies ? cookies.userSession : null
+                    cookies ? cookies.userSession : createFields.client_id
                 )
             )
             //Grant write access to the contributor that created the client

--- a/api/schema/resolvers/ClientResolver.js
+++ b/api/schema/resolvers/ClientResolver.js
@@ -52,24 +52,31 @@ module.exports = {
     },
     Mutation: {
         createClient: async (root, { createFields }, { cookies, models }) => {
-            const newlyCreatedClient = await models.Client.create({
-                ...createFields
-            })
-            const contributor = (
-                await models.Contributor.findByPk(
-                    cookies ? cookies.userSession : createFields.client_id
+            try {
+                const newlyCreatedClient = await models.Client.create({
+                    ...createFields
+                })
+                console.log('createFields');
+                console.log(createFields);
+                const contributor = (
+                    await models.Contributor.findByPk(
+                        cookies ? cookies.userSession : createFields.contributor_id
+                    )
                 )
-            )
-            //Grant write access to the contributor that created the client
-            const permissionAttributes = {
-                type: 'write',
-                contributor_id: contributor.id,
-                client_id: newlyCreatedClient.id
+                //Grant write access to the contributor that created the client
+                const permissionAttributes = {
+                    type: 'write',
+                    contributor_id: contributor.id,
+                    client_id: newlyCreatedClient.id
+                }
+                await models.Permission.create({
+                    ...permissionAttributes
+                })
+                return newlyCreatedClient
+            } catch (error) {
+                console.log('An error ocurred: ' + error);
             }
-            await models.Permission.create({
-                ...permissionAttributes
-            })
-            return newlyCreatedClient
+
         },
         deleteClientById: (root, { id }, { models }) => {
             return models.Client.destroy({ where: { id } })

--- a/api/schema/types/ClientType.js
+++ b/api/schema/types/ClientType.js
@@ -16,11 +16,19 @@ module.exports = gql`
         ): String
     }
 
+    input ClientCreateInput {
+        is_active: Boolean!,
+        name: String!,
+        email: String!,
+        currency: String!,
+        contributor_id: Int
+    }
+
     input ClientInput {
         is_active: Boolean,
         name: String,
         email: String,
-        currency: String,
+        currency: String
     }
 
     type Query {
@@ -31,7 +39,7 @@ module.exports = gql`
 
     type Mutation {
         createClient(
-            createFields: ClientInput!
+            createFields: ClientCreateInput!
         ): Client!
 
         deleteClientById(id: Int!): String

--- a/api/schema/types/ClientType.js
+++ b/api/schema/types/ClientType.js
@@ -17,10 +17,10 @@ module.exports = gql`
     }
 
     input ClientCreateInput {
-        is_active: Boolean!,
-        name: String!,
-        email: String!,
-        currency: String!,
+        is_active: Boolean,
+        name: String,
+        email: String,
+        currency: String,
         contributor_id: Int
     }
 

--- a/api/schema/types/ClientType.js
+++ b/api/schema/types/ClientType.js
@@ -19,9 +19,9 @@ module.exports = gql`
 
     input ClientCreateInput {
         is_active: Boolean,
-        name: String,
-        email: String,
-        currency: String,
+        name: String!,
+        email: String!
+        currency: String!
         contributor_id: Int
     }
 

--- a/src/operations/mutations/ClientMutations.js
+++ b/src/operations/mutations/ClientMutations.js
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 
 export const CREATE_CLIENT = gql`
-    mutation CreateClient($name: String!, $email: String, $currency: String) {
+    mutation CreateClient($name: String!, $email: String!, $currency: String!) {
         createClient(createFields:{
            name: $name,
            email: $email,


### PR DESCRIPTION
### **Issue #378**

**Description:** 

This pr contains the necessary changes to add a `client_id` column in the `Permissions table` to be able to control the permission level of the contributors. For now, the default permission is `write` access to the contributor that created the client

**Breakdown:** 

* The column was added via a new migration
* The `client_id` is of type Integer and could be nullable
* When a new client is created the permission is automatically created with the contributor_id and the `client_id`. The `contributor_id` is given via the cookies session, but in case we are adding the client directly from the Apollo server console, we have to pass the `contributor_id` as one of the parameters.

**Implementation proof:**

https://www.loom.com/share/980318d98496485e9dd768fc779df14b

**Note:**

We have to decide who's going to have `read` permission to the client, there are two options

1. All the contributors have `read` access to all the clients.
2. Only the contributors thas has `read` or `write` permission to at least one project owned by the client will have `read` access to that client. This can be a script that gets called every time a user logs in.

Once we decided which one of these will be I will open a new issue to implement it.

