### PR TITLE
Project end date on UI

### DIFF
--- a/api/migrations/20210318031244-addEndDateToProjects.js
+++ b/api/migrations/20210318031244-addEndDateToProjects.js
@@ -1,0 +1,19 @@
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        return queryInterface.sequelize.transaction(t => {
+            return Promise.all([
+                queryInterface.addColumn('Projects', 'end_date', {
+                    type: Sequelize.DataTypes.DATE
+                }, { transaction: t })
+            ])
+        })
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        return queryInterface.sequelize.transaction(t => {
+            return Promise.all([
+                queryInterface.removeColumn('Projects', 'end_date', { transaction: t })
+            ])
+        })
+    }
+};

--- a/api/models/Project.js
+++ b/api/models/Project.js
@@ -45,6 +45,9 @@ module.exports = (sequelize) => {
             type: DataTypes.DATE,
             allowNull: false
         },
+        end_date: {
+            type: DataTypes.DATE,
+        },
         date_last_synced: {
             type: DataTypes.DATE,
         },

--- a/api/schema/types/ProjectType.js
+++ b/api/schema/types/ProjectType.js
@@ -12,6 +12,7 @@ module.exports = gql`
         date: String!
         date_last_synced: String
         client_id: Int!
+        end_date: String
         toggl_id: String
         expected_budget_timeframe: String
         allocations(contributorId: Int): [Allocation]
@@ -91,6 +92,7 @@ module.exports = gql`
         toggl_url: String
         client_id: Int!
         date: String!
+        end_date: String
         expected_budget_timeframe: String
     }
 
@@ -103,6 +105,7 @@ module.exports = gql`
         client_id: Int
         toggl_id: String
         date: String
+        end_date: String
         date_last_synced:String
         expected_budget_timeframe: String
     }

--- a/src/components/AddProjectDetails.js
+++ b/src/components/AddProjectDetails.js
@@ -28,10 +28,12 @@ const AddProjectDetails = (props) => {
         budgetTimeframe,
         client,
         projectDate,
+        projectEndDate,
         projectName,
         setBudgetTimeframe,
         setProjectBudget,
         setProjectDate,
+        setProjectEndDate,
         setProjectName,
         setProjectToggl
     } = props
@@ -42,6 +44,9 @@ const AddProjectDetails = (props) => {
     }
     const handleDateChange = (date) => {
         setProjectDate(moment(date['_d']).format('YYYY-MM-DD'))
+    }
+    const handleEndDateChange = (date) => {
+        setProjectEndDate(moment(date['_d']).format('YYYY-MM-DD'))
     }
     const handleTimeframeChange = (timeframe) => {
         setBudgetTimeframe(timeframe)
@@ -64,7 +69,7 @@ const AddProjectDetails = (props) => {
     return (
         <Grid container justify='space-between'>
             <Grid item xs={12} md={5}>
-                <Box xs={10} mb={3}>
+                <Box>
                     <TextField
                         label='Project name'
                         id='projectName'
@@ -77,7 +82,7 @@ const AddProjectDetails = (props) => {
                 </Box>
             </Grid>
             <Grid item xs={12} md={5}>
-                <Box xs={10} mb={3}>
+                <Box>
                     <TextField
                         label='Toggl URL'
                         id='projectToggl'
@@ -88,23 +93,7 @@ const AddProjectDetails = (props) => {
                 </Box>
             </Grid>
             <Grid item xs={12} md={5}>
-                <Box xs={10} mb={3}>
-                    <CurrencyTextField
-                        fullWidth
-                        required
-                        label='Expected Budget'
-                        variant='outlined'
-                        currencySymbol={`${currencyInformation['symbol']}`}
-                        minimumValue='0'
-                        outputFormat='string'
-                        decimalCharacter={`${currencyInformation['decimal']}`}
-                        digitGroupSeparator={`${currencyInformation['thousand']}`}
-                        onChange={(event) => handleBudgetChange(event.target.value)}
-                    />
-                </Box>
-            </Grid>
-            <Grid item xs={12} md={5}>
-                <Box>
+                <Box mt={3}>
                     <MuiPickersUtilsProvider utils={MomentUtils}>
                         <KeyboardDatePicker
                             fullWidth
@@ -122,7 +111,40 @@ const AddProjectDetails = (props) => {
                 </Box>
             </Grid>
             <Grid item xs={12} md={5}>
-                <Box my={2}>
+                <Box mt={3}>
+                    <MuiPickersUtilsProvider utils={MomentUtils}>
+                        <KeyboardDatePicker
+                            fullWidth
+                            disableToolbar
+                            variant='inline'
+                            format='MM/DD/YYYY'
+                            margin='normal'
+                            id='date-picker-inline'
+                            label='Project end date'
+                            value={projectEndDate}
+                            onChange={handleEndDateChange}
+                        />
+                    </MuiPickersUtilsProvider>
+                </Box>
+            </Grid>
+            <Grid item xs={12} md={5}>
+                <Box mt={5}>
+                    <CurrencyTextField
+                        fullWidth
+                        required
+                        label='Expected Budget'
+                        variant='outlined'
+                        currencySymbol={`${currencyInformation['symbol']}`}
+                        minimumValue='0'
+                        outputFormat='string'
+                        decimalCharacter={`${currencyInformation['decimal']}`}
+                        digitGroupSeparator={`${currencyInformation['thousand']}`}
+                        onChange={(event) => handleBudgetChange(event.target.value)}
+                    />
+                </Box>
+            </Grid>
+            <Grid item xs={12} md={5}>
+                <Box mt={5}>
                     <FormControl fullWidth>
                         <InputLabel>
                             {`Expected budget timeframe`}

--- a/src/components/AddProjectForm.js
+++ b/src/components/AddProjectForm.js
@@ -69,7 +69,7 @@ const AddProjectForm = (props) => {
     const [projectToggl, setProjectToggl] = useState(null)
 
     useEffect(() => {
-        if (!projectName || !projectGithub || !projectDate || budgetTimeframe == null) {
+        if (!projectName || !projectGithub || !projectDate || !projectBudget || budgetTimeframe == null) {
             setDisableAdd(true)
         } else {
             setDisableAdd(false)
@@ -106,6 +106,7 @@ const AddProjectForm = (props) => {
             name: projectName,
             github_url: projectGithub,
             date: projectDate,
+            end_date: projectEndDate,
             expected_budget: Number(projectBudget),
             expected_budget_timeframe: EXPECTED_BUDGET_TIMEFRAME_OPTIONS[budgetTimeframe].value
         }
@@ -201,7 +202,7 @@ const AddProjectForm = (props) => {
                 </Box>
             </Grid>
             <Grid item xs={12}>
-                <Box mt={5}>
+                <Box mt={5} pt={5}>
                     <Button
                         variant='contained'
                         color='primary'

--- a/src/components/AddProjectForm.js
+++ b/src/components/AddProjectForm.js
@@ -62,6 +62,7 @@ const AddProjectForm = (props) => {
     const [linkedRepo, setLinkedRepo] = useState(false)
     const [projectBudget, setProjectBudget] = useState(0)
     const [projectDate, setProjectDate] = useState(null)
+    const [projectEndDate, setProjectEndDate] = useState(null)
     const [projectGithub, setProjectGithub] = useState(null)
     const [projectGithubManual, setProjectGithubManual] = useState(null)
     const [projectName, setProjectName] = useState('')
@@ -188,9 +189,11 @@ const AddProjectForm = (props) => {
                         budgetTimeframe={budgetTimeframe}
                         client={client}
                         projectDate={projectDate}
+                        projectEndDate={projectEndDate}
                         projectName={projectName}
                         setBudgetTimeframe={setBudgetTimeframe}
                         setProjectDate={setProjectDate}
+                        setProjectEndDate={setProjectEndDate}
                         setProjectName={setProjectName}
                         setProjectToggl={setProjectToggl}
                         setProjectBudget={setProjectBudget}

--- a/src/components/AddProjectFromGithub.js
+++ b/src/components/AddProjectFromGithub.js
@@ -97,7 +97,7 @@ const AddProjectFromGithub = (props) => {
             <Grid item xs={12} align='left'>
                 <Box my={3}>
                     <Typography>
-                        {`Search from a repo directly from Github`}
+                        {`Search for a repo directly from Github`}
                     </Typography>
                 </Box>
             </Grid>

--- a/src/components/ProjectEditDialog.js
+++ b/src/components/ProjectEditDialog.js
@@ -177,7 +177,7 @@ const ProjectEditDialog = (props) => {
                         alignItems='center'
                     >
                         <Grid item xs={12} lg={6}>
-                            <Box my={2} pr={1}>
+                            <Box my={2} px={1}>
                                 <TextField
                                     label='Project name'
                                     variant='outlined'
@@ -189,7 +189,7 @@ const ProjectEditDialog = (props) => {
                             </Box>
                         </Grid>
                         <Grid item xs={12} lg={6}>
-                            <Box my={2} pl={1}>
+                            <Box my={2} px={1}>
                                 <CurrencyTextField
                                     fullWidth
                                     label='Expected Budget'
@@ -205,7 +205,7 @@ const ProjectEditDialog = (props) => {
                             </Box>
                         </Grid>
                         <Grid item xs={12} lg={6}>
-                            <Box my={2} pr={1}>
+                            <Box my={2} px={1}>
                                 <TextField
                                     label='Github URL'
                                     variant='outlined'
@@ -217,7 +217,7 @@ const ProjectEditDialog = (props) => {
                             </Box>
                         </Grid>
                         <Grid item xs={12} lg={6}>
-                            <Box my={2}>
+                            <Box my={2} px={1}>
                                 <TextField
                                     label='Toggl URL'
                                     variant='outlined'
@@ -229,38 +229,44 @@ const ProjectEditDialog = (props) => {
                             </Box>
                         </Grid>
                         <Grid item xs={12} sm={6}>
-                            <MuiPickersUtilsProvider utils={MomentUtils}>
-                                <KeyboardDatePicker
-                                    disableToolbar
-                                    variant='inline'
-                                    format='MM/DD/YYYY'
-                                    margin='normal'
-                                    id='date-picker-inline'
-                                    label='Project start date'
-                                    value={projectDate}
-                                    onChange={handleDateChange}
-                                    KeyboardButtonProps={{
-                                        'aria-label': 'change date',
-                                    }}
-                                />
-                            </MuiPickersUtilsProvider>
+                            <Box px={1}>
+                                <MuiPickersUtilsProvider utils={MomentUtils}>
+                                    <KeyboardDatePicker
+                                        fullWidth
+                                        disableToolbar
+                                        variant='inline'
+                                        format='MM/DD/YYYY'
+                                        margin='normal'
+                                        id='date-picker-inline'
+                                        label='Project start date'
+                                        value={projectDate}
+                                        onChange={handleDateChange}
+                                        KeyboardButtonProps={{
+                                            'aria-label': 'change date',
+                                        }}
+                                    />
+                                </MuiPickersUtilsProvider>
+                            </Box>
                         </Grid>
                         <Grid item xs={12} sm={6}>
-                            <MuiPickersUtilsProvider utils={MomentUtils}>
-                                <KeyboardDatePicker
-                                    disableToolbar
-                                    variant='inline'
-                                    format='MM/DD/YYYY'
-                                    margin='normal'
-                                    id='date-picker-inline'
-                                    label='Project end date'
-                                    value={projectEndDate}
-                                    onChange={handleEndDateChange}
-                                />
-                            </MuiPickersUtilsProvider>
+                            <Box px={1}>
+                                <MuiPickersUtilsProvider utils={MomentUtils}>
+                                    <KeyboardDatePicker
+                                        fullWidth
+                                        disableToolbar
+                                        variant='inline'
+                                        format='MM/DD/YYYY'
+                                        margin='normal'
+                                        id='date-picker-inline'
+                                        label='Project end date'
+                                        value={projectEndDate}
+                                        onChange={handleEndDateChange}
+                                    />
+                                </MuiPickersUtilsProvider>
+                            </Box>
                         </Grid>
                         <Grid item xs={12} sm={6}>
-                            <Box mb={2} mr={3}>
+                            <Box my={2} px={1}>
                                 <FormControl fullWidth>
                                     <InputLabel>
                                         {`Expected budget timeframe`}

--- a/src/components/ProjectEditDialog.js
+++ b/src/components/ProjectEditDialog.js
@@ -43,6 +43,7 @@ const ProjectEditDialog = (props) => {
     } = props
 
     const currentDate = moment(project.date, 'x').format('YYYY-MM-DD')
+    const endDate = project.end_date ? moment(project.end_date, 'x').format('YYYY-MM-DD') : null
     const currencyInformation = selectCurrencyInformation({
         currency: project.client.currency
     })
@@ -56,6 +57,7 @@ const ProjectEditDialog = (props) => {
     const [expectedBudget, setExpectedBudget] = useState(project.expected_budget)
     const [githubURL, setGithubURL] = useState(project.github_url)
     const [projectDate, setProjectDate] = useState(null)
+    const [projectEndDate, setProjectEndDate] = useState(null)
     const [projectName, setProjectName] = useState(project.name)
     const [togglURL, setTogglURL] = useState(project.toggl_url)
 
@@ -71,6 +73,9 @@ const ProjectEditDialog = (props) => {
     }
     const handleDateChange = (date) => {
         setProjectDate(moment(date['_d']).format('YYYY-MM-DD'))
+    }
+    const handleEndDateChange = (date) => {
+        setProjectEndDate(moment(date['_d']).format('YYYY-MM-DD'))
     }
     const handleTimeframeChange = (timeframe) => {
         setBudgetTimeframe(timeframe)
@@ -91,6 +96,7 @@ const ProjectEditDialog = (props) => {
         const projectInfoToEdit = {
             project_id: project.id,
             date: projectDate,
+            end_date: projectEndDate,
             expected_budget: Number(expectedBudget),
             expected_budget_timeframe: (
                 budgetTimeframe != null
@@ -121,7 +127,8 @@ const ProjectEditDialog = (props) => {
                 ? EXPECTED_BUDGET_TIMEFRAME_OPTIONS[budgetTimeframe].label
                 : null
             ) == project.expected_budget_timeframe) &&
-            projectDate == currentDate
+            projectDate == currentDate &&
+            endDate == projectEndDate
         ) {
             setDisableEdit(true)
         } else if (!expectedBudget || !githubURL || !projectName) {
@@ -133,6 +140,9 @@ const ProjectEditDialog = (props) => {
 
     useEffect(() => {
         setProjectDate(currentDate)
+        if (endDate) {
+            setProjectEndDate(endDate)
+        }
         if (project.expected_budget_timeframe) {
             setBudgetTimeframe(
                 findIndex(EXPECTED_BUDGET_TIMEFRAME_OPTIONS, ['label', project.expected_budget_timeframe])
@@ -218,7 +228,7 @@ const ProjectEditDialog = (props) => {
                                 />
                             </Box>
                         </Grid>
-                        <Grid item xs={12}>
+                        <Grid item xs={12} sm={6}>
                             <MuiPickersUtilsProvider utils={MomentUtils}>
                                 <KeyboardDatePicker
                                     disableToolbar
@@ -226,7 +236,7 @@ const ProjectEditDialog = (props) => {
                                     format='MM/DD/YYYY'
                                     margin='normal'
                                     id='date-picker-inline'
-                                    label=''
+                                    label='Project start date'
                                     value={projectDate}
                                     onChange={handleDateChange}
                                     KeyboardButtonProps={{
@@ -235,8 +245,22 @@ const ProjectEditDialog = (props) => {
                                 />
                             </MuiPickersUtilsProvider>
                         </Grid>
-                        <Grid item xs={12} lg={6}>
-                            <Box mb={2}>
+                        <Grid item xs={12} sm={6}>
+                            <MuiPickersUtilsProvider utils={MomentUtils}>
+                                <KeyboardDatePicker
+                                    disableToolbar
+                                    variant='inline'
+                                    format='MM/DD/YYYY'
+                                    margin='normal'
+                                    id='date-picker-inline'
+                                    label='Project end date'
+                                    value={projectEndDate}
+                                    onChange={handleEndDateChange}
+                                />
+                            </MuiPickersUtilsProvider>
+                        </Grid>
+                        <Grid item xs={12} sm={6}>
+                            <Box mb={2} mr={3}>
                                 <FormControl fullWidth>
                                     <InputLabel>
                                         {`Expected budget timeframe`}

--- a/src/components/ProjectSummary.js
+++ b/src/components/ProjectSummary.js
@@ -90,7 +90,6 @@ const ProjectSummary = (props) => {
                                     <Icon className='far fa-flag' color='primary'/>
                                 </Grid>
                                 <Grid xs={10} align='left'>
-
                                     {`Start date - ${moment(project.date, 'x').format('MM/DD/YYYY')}`}
                                 </Grid>
                             </Grid>
@@ -102,7 +101,6 @@ const ProjectSummary = (props) => {
                                         <Icon className='fas fa-flag' color='primary'/>
                                     </Grid>
                                     <Grid xs={10} align='left'>
-
                                         {`End date - ${moment(project.end_date, 'x').format('MM/DD/YYYY')}`}
                                     </Grid>
                                 </Grid>

--- a/src/components/ProjectSummary.js
+++ b/src/components/ProjectSummary.js
@@ -87,7 +87,7 @@ const ProjectSummary = (props) => {
                         <Grid item xs={12}>
                             <Grid container>
                                 <Grid item xs={2}>
-                                    <Icon className='fas fa-flag' color='primary'/>
+                                    <Icon className='far fa-flag' color='primary'/>
                                 </Grid>
                                 <Grid xs={10} align='left'>
 
@@ -95,6 +95,19 @@ const ProjectSummary = (props) => {
                                 </Grid>
                             </Grid>
                         </Grid>
+                        {project.end_date &&
+                            <Grid item xs={12}>
+                                <Grid container>
+                                    <Grid item xs={2}>
+                                        <Icon className='fas fa-flag' color='primary'/>
+                                    </Grid>
+                                    <Grid xs={10} align='left'>
+
+                                        {`End date - ${moment(project.end_date, 'x').format('MM/DD/YYYY')}`}
+                                    </Grid>
+                                </Grid>
+                            </Grid>
+                        }    
                     </Grid>
                 </Grid>
                 <Grid

--- a/src/operations/mutations/ProjectMutations.js
+++ b/src/operations/mutations/ProjectMutations.js
@@ -1,13 +1,23 @@
 import { gql } from '@apollo/client';
 
 export const ADD_PROJECT = gql`
-    mutation createProject($client_id: Int!, $name:String!, $github_url: String!, $toggl_url: String, $date: String!, $expected_budget: Int!, $expected_budget_timeframe: String!){
+    mutation createProject(
+        $client_id: Int!,
+        $name:String!,
+        $github_url: String!,
+        $toggl_url: String,
+        $date: String!,
+        $end_date: String,
+        $expected_budget: Int!,
+        $expected_budget_timeframe: String!
+    ){
         createProject(createFields: {
             client_id: $client_id
             name: $name,
             github_url: $github_url,
             toggl_url: $toggl_url,
             date: $date,
+            end_date: $end_date,
             is_active: true,
             expected_budget :$expected_budget,
             expected_budget_timeframe: $expected_budget_timeframe

--- a/src/operations/mutations/ProjectMutations.js
+++ b/src/operations/mutations/ProjectMutations.js
@@ -3,7 +3,7 @@ import { gql } from '@apollo/client';
 export const ADD_PROJECT = gql`
     mutation createProject(
         $client_id: Int!,
-        $name:String!,
+        $name: String!,
         $github_url: String!,
         $toggl_url: String,
         $date: String!,

--- a/src/operations/mutations/ProjectMutations.js
+++ b/src/operations/mutations/ProjectMutations.js
@@ -48,7 +48,15 @@ export const SYNC_PROJECT_GITHUB_CONTRIBUTORS = gql`
  `
 
 export const UPDATE_PROJECT = gql`
-    mutation updateProjectById($project_id: Int!, $date: String!, $expected_budget:Int!, $name: String!, $github_url: String, $expected_budget_timeframe: String, $toggl_url: String){
+    mutation updateProjectById(
+        $project_id: Int!,
+        $date: String!,
+        $end_date: String,
+        $expected_budget:Int!, $name: String!,
+        $github_url: String,
+        $expected_budget_timeframe: String,
+        $toggl_url: String
+    ){
         updateProjectById(
             id: $project_id,
             updateFields: {
@@ -57,11 +65,14 @@ export const UPDATE_PROJECT = gql`
                 expected_budget_timeframe: $expected_budget_timeframe
                 toggl_url: $toggl_url
                 date: $date
+                end_date: $end_date
                 expected_budget: $expected_budget
             }
         ){
             id,
             name,
+            date,
+            end_date,
             expected_budget,
             expected_budget_timeframe,
             is_active,

--- a/src/operations/queries/ProjectQueries.js
+++ b/src/operations/queries/ProjectQueries.js
@@ -35,6 +35,7 @@ export const GET_PROJECT = gql`
             github_url
             toggl_url
             date
+            end_date
             totalPaid
             expected_budget_timeframe
             client {


### PR DESCRIPTION
### **Issue #377**

**Description:**

This pr implements the front-end side of adding `end_date` to the project table.
It is presented in:
* The form when creating a project
* The project overview page
* In the edit project overlay

**Breakdown:**

Nothing really special to point out here, I added the `end_date` attribute in the `GET_PROJECT` query and `CREATE_PROJECT` `EDIT_PROJECT` mutations, and using a date picker I added t to the create and edit project forms

**Implementation proof**

https://www.loom.com/share/3c0bebf37f924c64aa87cb29324f186d