### PR TITLE
Permissions migration script

### DIFF
--- a/api/modules/authentication.js
+++ b/api/modules/authentication.js
@@ -34,13 +34,13 @@ const authentication = module.exports = (() => {
         const projects = await db.models.Project.findAll({
             raw: true
         })
-        await projects.map(async p => {
+        await Promise.all(projects.map(async p => {
             await handleContributorPermission({
                 contributor: contributor,
                 githubContributor: githubContributor,
                 project: p,
             })
-        })
+        }))
     }
 
     const updateGithubAccessTokenContributor = async (githubContributor) => {

--- a/api/modules/authentication.js
+++ b/api/modules/authentication.js
@@ -30,14 +30,13 @@ const authentication = module.exports = (() => {
         }
     }
 
-    const grantProjectPermissions = async ({ contributor, githubContributor }) => {
+    const grantProjectPermissions = async ({ contributor }) => {
         const projects = await db.models.Project.findAll({
             raw: true
         })
         await Promise.all(projects.map(async p => {
             await handleContributorPermission({
                 contributor: contributor,
-                githubContributor: githubContributor,
                 project: p,
             })
         }))

--- a/api/modules/authentication.js
+++ b/api/modules/authentication.js
@@ -34,7 +34,7 @@ const authentication = module.exports = (() => {
         const projects = await db.models.Project.findAll({
             raw: true
         })
-        projects.map(async p => {
+        await projects.map(async p => {
             await handleContributorPermission({
                 contributor: contributor,
                 githubContributor: githubContributor,

--- a/api/modules/dataSyncs.js
+++ b/api/modules/dataSyncs.js
@@ -1,5 +1,6 @@
 const { split } = require('lodash')
 
+const authentication = require('./authentication')
 const amazon = require('../handlers/amazon')
 const github = require('../handlers/github')
 const toggl = require('../handlers/toggl')

--- a/api/schema/resolvers/PermissionResolver.js
+++ b/api/schema/resolvers/PermissionResolver.js
@@ -1,3 +1,5 @@
+const { authentication, dataSyncs } = require('../../modules')
+
 module.exports = {
     Permission: {
         contributor: (permission, args, { models }) => {
@@ -32,6 +34,28 @@ module.exports = {
                     contributor_id
                 }
             })
+        },
+    },
+    Mutation: {
+        syncContributorsPermissions: async (root, { github_access_token }, { models }) => {
+            const contributors = await models.Contributor.findAll({
+                raw: true
+            })
+            const result = []
+            await contributors.map(async c => {
+                if (c.github_access_token) {
+                    const githubContributor = {
+                        accessToken: github_access_token
+                    }
+                    result.push(await authentication.grantProjectPermissions({
+                        contributor: c,
+                        githubContributor: githubContributor
+                    }))
+                }
+            })
+            console.log('result');
+            console.log(result);
+            return result.length
         }
     }
 }

--- a/api/schema/resolvers/PermissionResolver.js
+++ b/api/schema/resolvers/PermissionResolver.js
@@ -46,11 +46,11 @@ module.exports = {
             const contributors = await models.Contributor.findAll({
                 raw: true
             })
-            await Promise.all(contributors.map(async c => {
+            contributors.map(async c => {
                 await authentication.grantProjectPermissions({
                     contributor: c
                 })
-            }))
+            })
             return contributors.length
         }
     }

--- a/api/schema/resolvers/PermissionResolver.js
+++ b/api/schema/resolvers/PermissionResolver.js
@@ -41,21 +41,18 @@ module.exports = {
             const contributors = await models.Contributor.findAll({
                 raw: true
             })
-            const result = []
-            await contributors.map(async c => {
+            await Promise.all(contributors.map(async c => {
                 if (c.github_access_token) {
                     const githubContributor = {
                         accessToken: github_access_token
                     }
-                    result.push(await authentication.grantProjectPermissions({
+                    await authentication.grantProjectPermissions({
                         contributor: c,
                         githubContributor: githubContributor
-                    }))
+                    })
                 }
-            })
-            console.log('result');
-            console.log(result);
-            return result.length
+            }))
+            return contributors.length
         }
     }
 }

--- a/api/schema/resolvers/PermissionResolver.js
+++ b/api/schema/resolvers/PermissionResolver.js
@@ -37,6 +37,11 @@ module.exports = {
         },
     },
     Mutation: {
+        createPermission: (root, { createFields }, { models }) => {
+            return models.Permission.create({
+                ...createFields
+            })
+        },
         syncContributorsPermissions: async (root, { github_access_token }, { models }) => {
             const contributors = await models.Contributor.findAll({
                 raw: true

--- a/api/schema/resolvers/PermissionResolver.js
+++ b/api/schema/resolvers/PermissionResolver.js
@@ -42,20 +42,14 @@ module.exports = {
                 ...createFields
             })
         },
-        syncContributorsPermissions: async (root, { github_access_token }, { models }) => {
+        syncContributorsPermissions: async (root, args, { models }) => {
             const contributors = await models.Contributor.findAll({
                 raw: true
             })
             await Promise.all(contributors.map(async c => {
-                if (c.github_access_token) {
-                    const githubContributor = {
-                        accessToken: github_access_token
-                    }
-                    await authentication.grantProjectPermissions({
-                        contributor: c,
-                        githubContributor: githubContributor
-                    })
-                }
+                await authentication.grantProjectPermissions({
+                    contributor: c
+                })
             }))
             return contributors.length
         }

--- a/api/schema/resolvers/ProjectResolver.js
+++ b/api/schema/resolvers/ProjectResolver.js
@@ -530,7 +530,7 @@ module.exports = {
         }
     },
     Mutation: {
-        createProject: (root, { createFields }, { models }) => {
+        createProject: async (root, { createFields }, { models }) => {
             validateDatesFormat({
                 date: createFields['date']
             })
@@ -543,9 +543,13 @@ module.exports = {
                 const togglId = togglArray[togglArray.length - 1]
                 projectToCreate['toggl_id'] = togglId
             }
-            return models.Project.create({
+            const newProject = await models.Project.create({
                 ...projectToCreate
             })
+            if (newProject.id) {
+                //create owner permission to contributor who created the project
+            }
+            return newProject
         },
         deleteProjectById: (root, { id }, { models }) => {
             return models.Project.destroy({ where: { id } })

--- a/api/schema/types/PermissionType.js
+++ b/api/schema/types/PermissionType.js
@@ -26,7 +26,7 @@ module.exports = gql`
     }
     type Mutation {
         createPermission(createFields: CreatePermissionInput): Permission
-        syncContributorsPermissions(github_access_token: String!): Int
+        syncContributorsPermissions: Int
     }
 
 `

--- a/api/schema/types/PermissionType.js
+++ b/api/schema/types/PermissionType.js
@@ -18,5 +18,8 @@ module.exports = gql`
             contributor_id: Int!
         ): Permission
     }
+    type Mutation {
+        syncContributorsPermissions(github_access_token: String!): Int
+    }
 
 `

--- a/api/schema/types/PermissionType.js
+++ b/api/schema/types/PermissionType.js
@@ -3,10 +3,11 @@ const { gql } = require('apollo-server')
 module.exports = gql`
 
     type Permission {
+        id: Int!
         type: String!
         contributor_id: Int!
-        contributor: Contributor!
         project_id: Int!
+        contributor: Contributor!
         project: Project!
     }
     type Query {
@@ -18,7 +19,13 @@ module.exports = gql`
             contributor_id: Int!
         ): Permission
     }
+    input CreatePermissionInput {
+        contributor_id: Int!
+        project_id: Int!
+        type: String!
+    }
     type Mutation {
+        createPermission(createFields: CreatePermissionInput): Permission
         syncContributorsPermissions(github_access_token: String!): Int
     }
 

--- a/api/scripts/githubPermissions.js
+++ b/api/scripts/githubPermissions.js
@@ -16,12 +16,22 @@ module.exports = (() => {
         })
     }
 
-    const handleContributorPermission = async ({ contributor, githubContributor, project }) => {
+    const handleContributorPermission = async ({ contributor, project }) => {
+        const projectOwner = await db.models.Contributor.findOne({
+            include: [{
+                model: db.models.Permission,
+                where: {
+                    project_id: project.id,
+                    type: 'owner'
+                }
+            }],
+            raw: true
+        })
         const repoInfo = split(project.github_url, '/')
         const contributorInfo = split(contributor.github_handle, '/')
         try {
             const githubContributorPermission = await fetchUserPermission({
-                auth_key: githubContributor.accessToken,
+                auth_key: projectOwner.github_access_token,
                 owner: repoInfo[repoInfo.length - 2],
                 repo: repoInfo[repoInfo.length - 1],
                 username: contributorInfo[contributorInfo.length - 1]

--- a/api/tests/github.js
+++ b/api/tests/github.js
@@ -48,7 +48,6 @@ const userData = github.fetchAuthUserData({ auth_key: '' })
 //         console.log(err);
 //     })
 
-
 const issues = github.fetchRepoIssues({
     auth_key: '',
     repo: 'project-trinary',

--- a/server.js
+++ b/server.js
@@ -93,8 +93,7 @@ app.get('/api/oauth-redirect', (req, res) => { //redirects to the url configured
         .then((contributorInfo) => {
             //sync the permissions for the contributor
             apiModules.authentication.grantProjectPermissions({
-                contributor: contributorInfo.contributor.dataValues,
-                githubContributor: contributorInfo.githubContributor
+                contributor: contributorInfo.contributor.dataValues
             })
         })
         .then(() => {

--- a/src/components/AddProjectForm.js
+++ b/src/components/AddProjectForm.js
@@ -19,6 +19,7 @@ import AddProjectDetails from './AddProjectDetails'
 import AddProjectFromGithub from './AddProjectFromGithub'
 import LoadingProgress from './LoadingProgress'
 
+import { sessionUser } from '../reactivities/variables'
 import {
     verifyGithubURL,
     verifyTogglURL
@@ -26,6 +27,7 @@ import {
 import { EXPECTED_BUDGET_TIMEFRAME_OPTIONS } from '../constants'
 import { GET_CLIENT_INFO } from '../operations/queries/ClientQueries'
 import { ADD_PROJECT } from '../operations/mutations/ProjectMutations'
+import { CREATE_PERMISSION } from '../operations/mutations/PermissionMutations'
 
 const AddProjectForm = (props) => {
 
@@ -52,6 +54,16 @@ const AddProjectForm = (props) => {
             loading,
             error
         }] = useMutation(ADD_PROJECT, {
+        errorPolicy: 'all'
+    })
+
+    const [
+        createPermission,
+        {
+            data: dataNewPermission,
+            loadin: loadingNewPermission,
+            error: errorNewPermission
+        }] = useMutation(CREATE_PERMISSION, {
         errorPolicy: 'all'
     })
 
@@ -100,7 +112,7 @@ const AddProjectForm = (props) => {
                 return
             }
         }
-        const variables = {
+        const newProjectVariables = {
             client_id: Number(clientId),
             name: projectName,
             github_url: projectGithub,
@@ -109,14 +121,20 @@ const AddProjectForm = (props) => {
             expected_budget_timeframe: EXPECTED_BUDGET_TIMEFRAME_OPTIONS[budgetTimeframe].value
         }
         if (projectToggl) {
-            variables.toggl_url = projectToggl
+            newProjectVariables.toggl_url = projectToggl
         }
-        const newProject = await addProject({ variables })
+        const newProject = await addProject({ variables: newProjectVariables })
         if (loading) return <LoadingProgress/>
         if (newProject.errors) {
             setCreateProjectError(`${Object.keys(newProject.errors[0].extensions.exception.fields)[0]} already exists`)
             setDisplayError(true)
         } else {
+            const newPermission = await createPermission({
+                variables: {
+                    contributor_id: sessionUser().id,
+                    project_id: newProject.data.createProject.id,
+                    type: 'owner'
+                } })
             history.push(`/projects/${newProject.data.createProject.id}`)
         }
     }
@@ -127,7 +145,6 @@ const AddProjectForm = (props) => {
         }
         setDisplayError(false)
     }
-
     if (errorClient) return `An error ocurred: ${errorClient}`
     if (loadingClient) return <LoadingProgress/>
 

--- a/src/components/Authentication.js
+++ b/src/components/Authentication.js
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react'
-import { useQuery } from '@apollo/client'
+import { makeVar, useQuery } from '@apollo/client';
 
 import LoadingProgress from './LoadingProgress'
 
-import { authUser } from '../reactivities/variables'
+import { authUser, sessionUser } from '../reactivities/variables'
 import { CHECK_SESSION } from '../operations/queries/ContributorQueries'
 
 const Authentication = () => {
@@ -15,6 +15,9 @@ const Authentication = () => {
             if (!data.checkSession) {
                 authUser(false)
             } else {
+                console.log('{ ...data.checkSession }');
+                console.log({ ...data.checkSession });
+                sessionUser({ ...data.checkSession })
                 authUser(true)
             }
         }

--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -7,7 +7,7 @@ import { CHECK_SESSION } from '../operations/queries/ContributorQueries'
 
 const PrivateRoute = (props) => {
 
-    //IMPORTANT: use CHECK_SESSION qeury for reloading and staying on sape page
+    //IMPORTANT: use CHECK_SESSION query for reloading and staying on sape page
     const { error, loading, data } = useQuery(CHECK_SESSION)
 
     if (loading) {

--- a/src/operations/mutations/PermissionMutations.js
+++ b/src/operations/mutations/PermissionMutations.js
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client';
+
+export const CREATE_PERMISSION = gql`
+    mutation CreatePermission($contributor_id: Int!, $project_id: Int!, $type: String!) {
+        createPermission(createFields: {
+            contributor_id: $contributor_id
+            project_id: $project_id
+            type: $type
+        }) {
+            id
+        }
+    }
+`

--- a/src/reactivities/variables.js
+++ b/src/reactivities/variables.js
@@ -1,4 +1,5 @@
 import { makeVar } from '@apollo/client'
 
 export const authUser = makeVar(false)
+export const sessionUser = makeVar({})
 export const pageName = makeVar('')


### PR DESCRIPTION
### **Issue #379**

**Important:**

This branch was branched off from #382 so have all the changes of that branch

**Description:**

This pr consists of making and running a script that will create permission for the relation contributor-project. These permissions will come from GitHub as described in #382 

**Breakdown**:

* I recommend reading #382 pr description. 
* Besides using all logic implemented in #382 to run this script you need to go to the apollo console and run `syncContributorsPermissions` that takes  the GitHub API key from the contributor as parameter making the request and will return the number of contributors
* This will sync the permission relation between contributor-project but not contributor-client

**Implementation proof:**

https://www.loom.com/share/c8e90a71cf1a4bdf98e6143adf68ff49