### PR TITLE
Add External Uuid to client model

### DIFF
--- a/api/migrations/20210420213143-addExternalUuidToClient.js
+++ b/api/migrations/20210420213143-addExternalUuidToClient.js
@@ -1,0 +1,19 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        queryInterface.addColumn('Clients', 'external_uuid', {
+          type: Sequelize.DataTypes.STRING
+        }, { transaction: t })
+      ])
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        queryInterface.removeColumn('Clients', 'external_uuid', { transaction: t })
+      ])
+    })
+  }
+};

--- a/api/models/Client.js
+++ b/api/models/Client.js
@@ -27,6 +27,9 @@ module.exports = (sequelize) => {
         currency: {
             type: DataTypes.STRING,
             allowNull: false
+        },
+        external_uuid: {
+            type: DataTypes.STRING
         }
     },
     {

--- a/api/models/Client.js
+++ b/api/models/Client.js
@@ -41,5 +41,4 @@ module.exports = (sequelize) => {
     });
 
     return Client
-
 }

--- a/api/schema/types/ClientType.js
+++ b/api/schema/types/ClientType.js
@@ -8,6 +8,7 @@ module.exports = gql`
         name: String!
         email: String!
         currency: String!
+        external_uuid: String!
         payments: [Payment]
         projects: [Project]
         totalPaid(


### PR DESCRIPTION
**Issue 394**

Create the external_uuid row in the client table of the data base, so we can save the stripe id of the client.
The row is nulleable so that when a client is created from trinary there are no conflicts waiting for the client to be created in stripe.

**Implementation proof**
![imagen](https://user-images.githubusercontent.com/36824674/115469184-29cf0700-a202-11eb-8f0e-9b7562214080.png)
