### PR TITLE
Sync Stripe customers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
         'jsx-quotes': ['error', 'prefer-single'],
         'keyword-spacing': ['error', { 'after': true }],
         'lines-between-class-members': 'off',
-        //'linebreak-style': ['error', 'off'],
+        'linebreak-style': ['error', 'windows'], //For windows user using ESlint.
         'max-len': 'off',
         'new-cap': 'off',
         'no-bitwise': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
         'jsx-quotes': ['error', 'prefer-single'],
         'keyword-spacing': ['error', { 'after': true }],
         'lines-between-class-members': 'off',
-        'linebreak-style': ['error', 'windows'], //For windows user using ESlint.
+        //'linebreak-style': ['error', 'off'],
         'max-len': 'off',
         'new-cap': 'off',
         'no-bitwise': 'off',

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -19,7 +19,29 @@ const automations = module.exports = (() => {
                 external_uuid: clientInformation.external_uuid
             })
         }
+    }
 
+    const updateClient = async (params) => {
+        const clientToUpdate = await db.models.Client.findOne({
+            where: {
+                external_uuid: params.clientInformation.external_uuid
+            }
+        })
+        if (clientToUpdate) {
+            return db.models.Client.update({
+                email: params.clientInformation.email,
+                currency: params.clientInformation.currency,
+                name: params.clientInformation.name,
+                updated_at: moment(params.clientInformation.date_created),
+                external_uuid: params.clientInformation.external_uuid
+            }, {
+                where: {
+                    id: clientToUpdate.id
+                }
+            })
+        } else {
+            createClient({ clientInformation: params.clientInformation })
+        }
     }
 
     const createPayment = async ({ paymentInformation }) => {
@@ -139,6 +161,7 @@ const automations = module.exports = (() => {
 
     return {
         createClient,
+        updateClient,
         createPayment,
         getUserOrganizations,
         getOrganizationRepos,

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -6,6 +6,22 @@ const db = require('../models')
 
 const automations = module.exports = (() => {
 
+    const createClient = async ({ clientInformation }) => {
+        const client = await getClientFromExternalId({ id: clientInformation.external_uuid })
+        if (!client) {
+            return db.models.Client.create({
+                email: clientInformation.email,
+                currency: clientInformation.currency,
+                name: clientInformation.description,
+                is_active: 1,
+                created_at: moment(clientInformation.date_created),
+                updated_at: moment(clientInformation.date_created),
+                external_uuid: clientInformation.external_uuid
+            })
+        }
+
+    }
+
     const createPayment = async ({ paymentInformation }) => {
         const client = await getClientFromExternalId({ id: paymentInformation.customer_id })
         if (client) {
@@ -122,6 +138,7 @@ const automations = module.exports = (() => {
     }
 
     return {
+        createClient,
         createPayment,
         getUserOrganizations,
         getOrganizationRepos,

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -9,7 +9,7 @@ const automations = module.exports = (() => {
     const createClient = async ({ clientInformation }) => {
         const client = await getClientFromExternalId({ id: clientInformation.external_uuid })
         const email = await getClientFromEmail( { email: clientInformation.email })
-        if (!client || !email) {
+        if (!client && !email) {
             return db.models.Client.create({
                 email: clientInformation.email,
                 currency: clientInformation.currency,
@@ -19,7 +19,7 @@ const automations = module.exports = (() => {
                 updated_at: moment(clientInformation.date_created),
                 external_uuid: clientInformation.external_uuid
             })
-        } else if (!client || email) {
+        } else if ((!client && email) || (client && email)) {
             updateClient({ clientInformation: clientInformation})
         }
     }
@@ -32,14 +32,14 @@ const automations = module.exports = (() => {
                     external_uuid: params.clientInformation.external_uuid
                 }
             })
-        }else{
+        }
+        if (params.clientInformation.email && (clientToUpdate === null)){
             clientToUpdate = await db.models.Client.findOne({
                 where: {
                     email: params.clientInformation.email
                 }
             })
         }
-
         if (clientToUpdate) {
             return db.models.Client.update({
                 email: params.clientInformation.email,

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -19,7 +19,7 @@ const automations = module.exports = (() => {
                 updated_at: moment(clientInformation.date_created),
                 external_uuid: clientInformation.external_uuid
             })
-        } else if ((!client && email) || (client && email)) {
+        } else {
             updateClient({ clientInformation: clientInformation})
         }
     }

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -12,7 +12,7 @@ const automations = module.exports = (() => {
             return db.models.Client.create({
                 email: clientInformation.email,
                 currency: clientInformation.currency,
-                name: clientInformation.description,
+                name: clientInformation.name,
                 is_active: 1,
                 created_at: moment(clientInformation.date_created),
                 updated_at: moment(clientInformation.date_created),

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -18,20 +18,20 @@ const automations = module.exports = (() => {
                 external_uuid: clientInformation.external_uuid
             })
         } else {
-            updateClient({ clientInformation: clientInformation})
+            updateClient({ clientInformation: clientInformation })
         }
     }
 
     const updateClient = async (params) => {
         let clientToUpdate
-        if (params.clientInformation.external_uuid){
+        if (params.clientInformation.external_uuid) {
             clientToUpdate = await db.models.Client.findOne({
                 where: {
                     external_uuid: params.clientInformation.external_uuid
                 }
             })
         }
-        if (params.clientInformation.email && (clientToUpdate === null)){
+        if (params.clientInformation.email && (clientToUpdate === null)) {
             clientToUpdate = await db.models.Client.findOne({
                 where: {
                     email: params.clientInformation.email
@@ -70,7 +70,6 @@ const automations = module.exports = (() => {
             }
         })
     }
-
 
     const getClientFromExternalId = (params) => {
         return db.models.Client.findOne({

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -15,8 +15,6 @@ const automations = module.exports = (() => {
                 currency: clientInformation.currency,
                 name: clientInformation.name,
                 is_active: 1,
-                created_at: moment(clientInformation.date_created),
-                updated_at: moment(clientInformation.date_created),
                 external_uuid: clientInformation.external_uuid
             })
         } else {
@@ -41,17 +39,11 @@ const automations = module.exports = (() => {
             })
         }
         if (clientToUpdate) {
-            return db.models.Client.update({
-                email: params.clientInformation.email,
-                currency: params.clientInformation.currency,
-                name: params.clientInformation.name,
-                updated_at: moment(params.clientInformation.date_created),
-                external_uuid: params.clientInformation.external_uuid
-            }, {
-                where: {
-                    id: clientToUpdate.id
-                }
-            })
+            clientToUpdate.email = params.clientInformation.email
+            clientToUpdate.currency = params.clientInformation.currency
+            clientToUpdate.name = params.clientInformation.name
+            clientToUpdate.external_uuid = params.clientInformation.external_uuid
+            await clientToUpdate.save()
         } else {
             createClient({ clientInformation: params.clientInformation })
         }

--- a/api/tests/fixtures/createClient.json
+++ b/api/tests/fixtures/createClient.json
@@ -1,0 +1,16 @@
+{
+  "_meta": {
+    "template_version": 0
+  },
+  "fixtures": [
+    {
+      "name": "client_created",
+      "path": "/v1/customers",
+      "method": "post",
+      "params": {
+        "description": "Test Customer",
+        "email": "test@setlife.com"
+      }
+    }
+  ]
+}

--- a/server.js
+++ b/server.js
@@ -179,7 +179,7 @@ app.use('/api/graph/v/:vid', express.json(), (req, res, next) => {
     next()
 })
 
-app.post('/api/webhooks/clients/created',express.json(), (req, res, next) => {
+app.post('/api/webhooks/clients',express.json(), (req, res, next) => {
     const body = req.body.data.object
     const clientInformation = {
         email: body.email,
@@ -188,13 +188,24 @@ app.post('/api/webhooks/clients/created',express.json(), (req, res, next) => {
         date_created: req.body.created,
         external_uuid: body.id
     }
-    apiModules.automations.createClient({ clientInformation})
-        .then(()=>{
-            res.sendStatus(200)
-        })
-        .catch(err => {
-            console.log(`An error ocurred: ${err}`)
-        })
+    const webhookType = req.body.type
+    if (webhookType === "customer.created"){
+        apiModules.automations.createClient({ clientInformation})
+            .then(()=>{
+                res.sendStatus(200)
+            })
+            .catch(err => {
+                console.log(`An error ocurred: ${err}`)
+            })
+    }else if (webhookType === "customer.updated"){
+        apiModules.automations.updateClient({ clientInformation })
+            .then(()=>{
+                res.sendStatus(200)
+            })
+            .catch(err => {
+                console.log(`An error ocurred: ${err}`)
+            })
+    }
 })
 
 const server = new ApolloServer({

--- a/server.js
+++ b/server.js
@@ -187,7 +187,14 @@ app.post('/api/webhooks/clients/created',express.json(), (req, res, next) => {
         currency: body.currency,
         name: body.description
     }
-    res.sendStatus(200)
+    apiModules.automations.createClient({ clientInformation})
+        .then(()=>{
+            res.sendStatus(200)
+        })
+        .catch(err => {
+            console.log(`An error ocurred: ${err}`)
+        })
+
 })
 
 const server = new ApolloServer({

--- a/server.js
+++ b/server.js
@@ -110,6 +110,11 @@ app.use('/api/graph/v/:vid', express.json(), (req, res, next) => {
     next()
 })
 
+app.post('/api/webhooks/clients/created',express.json(), (req, res, next) => {
+    console.log(req.body)
+    res.sendStatus(200)
+})
+
 const server = new ApolloServer({
     schema,
     context: ({ req }) => ({

--- a/server.js
+++ b/server.js
@@ -171,7 +171,7 @@ app.post('/api/webhooks/clients', express.json(), (req, res, next) => {
         external_uuid: clientData.id
     }
     const webhookType = req.body.type
-    if (webhookType === 'customer.created'){
+    if (webhookType === 'customer.created') {
         apiModules.automations.createClient({ clientInformation })
             .then(() => {
                 res.sendStatus(200)
@@ -179,7 +179,7 @@ app.post('/api/webhooks/clients', express.json(), (req, res, next) => {
             .catch(err => {
                 console.log(`An error ocurred: ${err}`)
             })
-    }else if (webhookType === "customer.updated"){
+    } else if (webhookType === 'customer.updated' ) {
         apiModules.automations.updateClient({ clientInformation })
             .then(() => {
                 res.sendStatus(200)

--- a/server.js
+++ b/server.js
@@ -182,11 +182,13 @@ app.use('/api/graph/v/:vid', express.json(), (req, res, next) => {
 app.post('/api/webhooks/clients/created',express.json(), (req, res, next) => {
     const body = req.body.data.object
     const clientInformation = {
-        external_uuid: body.id,
         email: body.email,
         currency: body.currency,
-        name: body.description
+        name: body.description,
+        date_created: req.body.created,
+        external_uuid: body.id
     }
+    console.log(clientInformation)
     apiModules.automations.createClient({ clientInformation})
         .then(()=>{
             res.sendStatus(200)

--- a/server.js
+++ b/server.js
@@ -160,7 +160,7 @@ app.post('/api/webhooks/payment_intent/succeeded', (req, res) => {
     }
 })
 
-app.post('/api/webhooks/clients', (req, res, next) => {
+app.post('/api/webhooks/clients', async (req, res, next) => {
 
     const clientData = req.body.data.object
     const clientInformation = {
@@ -172,21 +172,19 @@ app.post('/api/webhooks/clients', (req, res, next) => {
     }
     const webhookType = req.body.type
     if (webhookType === 'customer.created') {
-        apiModules.automations.createClient({ clientInformation })
-            .then(() => {
-                res.sendStatus(200)
-            })
-            .catch(err => {
-                console.log(`An error ocurred: ${err}`)
-            })
+        try {
+            await apiModules.automations.createClient({ clientInformation })
+            res.sendStatus(200)
+        } catch (err) {
+            console.log(`An error ocurred: ${err}`)
+        }
     } else if (webhookType === 'customer.updated' ) {
-        apiModules.automations.updateClient({ clientInformation })
-            .then(() => {
-                res.sendStatus(200)
-            })
-            .catch(err => {
-                console.log(`An error ocurred: ${err}`)
-            })
+        try {
+            await apiModules.automations.updateClient({ clientInformation })
+            res.sendStatus(200)
+        } catch (err) {
+            console.log(`An error ocurred: ${err}`)
+        }
     }
 })
 

--- a/server.js
+++ b/server.js
@@ -184,11 +184,10 @@ app.post('/api/webhooks/clients/created',express.json(), (req, res, next) => {
     const clientInformation = {
         email: body.email,
         currency: body.currency,
-        name: body.description,
+        name: body.name,
         date_created: req.body.created,
         external_uuid: body.id
     }
-    console.log(clientInformation)
     apiModules.automations.createClient({ clientInformation})
         .then(()=>{
             res.sendStatus(200)
@@ -196,7 +195,6 @@ app.post('/api/webhooks/clients/created',express.json(), (req, res, next) => {
         .catch(err => {
             console.log(`An error ocurred: ${err}`)
         })
-
 })
 
 const server = new ApolloServer({

--- a/server.js
+++ b/server.js
@@ -179,19 +179,20 @@ app.use('/api/graph/v/:vid', express.json(), (req, res, next) => {
     next()
 })
 
-app.post('/api/webhooks/clients',express.json(), (req, res, next) => {
-    const body = req.body.data.object
+app.post('/api/webhooks/clients', express.json(), (req, res, next) => {
+
+    const clientData = req.body.data.object
     const clientInformation = {
-        email: body.email,
-        currency: body.currency,
-        name: body.name,
+        email: clientData.email,
+        currency: clientData.currency,
+        name: clientData.name,
         date_created: req.body.created,
-        external_uuid: body.id
+        external_uuid: clientData.id
     }
     const webhookType = req.body.type
-    if (webhookType === "customer.created"){
-        apiModules.automations.createClient({ clientInformation})
-            .then(()=>{
+    if (webhookType === 'customer.created'){
+        apiModules.automations.createClient({ clientInformation })
+            .then(() => {
                 res.sendStatus(200)
             })
             .catch(err => {
@@ -199,7 +200,7 @@ app.post('/api/webhooks/clients',express.json(), (req, res, next) => {
             })
     }else if (webhookType === "customer.updated"){
         apiModules.automations.updateClient({ clientInformation })
-            .then(()=>{
+            .then(() => {
                 res.sendStatus(200)
             })
             .catch(err => {

--- a/server.js
+++ b/server.js
@@ -160,7 +160,7 @@ app.post('/api/webhooks/payment_intent/succeeded', (req, res) => {
     }
 })
 
-app.post('/api/webhooks/clients', express.json(), (req, res, next) => {
+app.post('/api/webhooks/clients', (req, res, next) => {
 
     const clientData = req.body.data.object
     const clientInformation = {

--- a/server.js
+++ b/server.js
@@ -111,7 +111,13 @@ app.use('/api/graph/v/:vid', express.json(), (req, res, next) => {
 })
 
 app.post('/api/webhooks/clients/created',express.json(), (req, res, next) => {
-    console.log(req.body)
+    const body = req.body.data.object
+    const clientInformation = {
+        external_uuid: body.id,
+        email: body.email,
+        currency: body.currency,
+        name: body.description
+    }
     res.sendStatus(200)
 })
 


### PR DESCRIPTION
**Issue #393**

**Description**

In this Pull Request the following is implemented:

* When the webhook `customer.created` and `customer.updated` its triggered to the endpoint `/api/webhooks/clients`  it creates in the DB the new client or it updates the client, according to the type key.

**Breakdown**

* Initially the endpoint for this webhook was  `/api/webhooks/clients/created` or `/api/webhooks/clients/updated`  but the webhook json file has a "type" key that distinguishes what type of hook it is:
```
 "type": "customer.updated",
```
So with this key you can compare between a created client or updated one.
* When a new client its created, the `external_uuid` row is filled with the customer id from Stripe, the same happends with an updated client, if it does not have the `external_uuid` that its trying to update it creates the new client with the `external_uuid`

**Implementation proof**

https://user-images.githubusercontent.com/36824674/117694794-8aac8800-b18d-11eb-84c7-f4208151001d.mp4


