### PR TITLE
Stripe invoices uneditable

### DIFF
--- a/api/models/Payment.js
+++ b/api/models/Payment.js
@@ -21,6 +21,9 @@ module.exports = (sequelize) => {
             type: DataTypes.STRING,
             unique: true
         },
+        external_uuid_type: {
+            type: DataTypes.STRING
+        },
         date_incurred: {
             type: DataTypes.DATE,
             allowNull: false

--- a/api/schema/types/PaymentType.js
+++ b/api/schema/types/PaymentType.js
@@ -9,6 +9,8 @@ module.exports = gql`
         date_paid: String
         client_id: Int!
         totalAllocated: Int
+        external_uuid: String
+        external_uuid_type: String
         client: Client
         allocations: [Allocation]
     }

--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -96,6 +96,7 @@ const PaymentTile = (props) => {
         amount: payment.amount / 100,
         currencyInformation: currencyInformation
     })
+    const paymentIsEditable = payment.external_uuid_type
     const numberOfContributorsAllocated = allocations.length
 
     const renderPaymentAllocations = (props) => {
@@ -214,6 +215,7 @@ const PaymentTile = (props) => {
                                     <Button
                                         color='primary'
                                         onClick={() => handleEditPayment(true)}
+                                        disabled={paymentIsEditable}
                                     >
                                         {'Edit Payment'.toUpperCase()}
                                     </Button>

--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -96,7 +96,6 @@ const PaymentTile = (props) => {
         amount: payment.amount / 100,
         currencyInformation: currencyInformation
     })
-    const paymentIsEditable = payment.external_uuid_type
     const numberOfContributorsAllocated = allocations.length
 
     const renderPaymentAllocations = (props) => {
@@ -215,7 +214,7 @@ const PaymentTile = (props) => {
                                     <Button
                                         color='primary'
                                         onClick={() => handleEditPayment(true)}
-                                        disabled={paymentIsEditable}
+                                        disabled={payment.external_uuid_type}
                                     >
                                         {'Edit Payment'.toUpperCase()}
                                     </Button>

--- a/src/operations/queries/PaymentQueries.js
+++ b/src/operations/queries/PaymentQueries.js
@@ -9,6 +9,8 @@ export const GET_CLIENT_PAYMENTS = gql`
             amount
             date_incurred
             date_paid
+            external_uuid
+            external_uuid_type
             client {
                 id
                 name


### PR DESCRIPTION
### **Issue #403**

**Description:**

In this pr I make the necessary changes to no be able to edit from Trinary a payment that came from an external source like Stripe

**Breakdown:**
* I had to make changes both to the frontend and backend
* For the backend, I added the missing attributes `external_uuid` and `external_uuid_type` to the type to be able to fetch them from the frontend
* In the frontend I added these two attributes into the `GET_CLIENT_PAYMENTS` query
* On the PaymentTile I check if there's an external uuid the `disabled` attribute on the `Edit Payment`  button is true and it's disabled for clicking

**implementation proof**
https://www.loom.com/share/96a535b064a94c6d8fe22ee1ca25a431
