### PR TITLE
Webhook for deleting Draft Invoices

### DIFF
--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -20,6 +20,20 @@ const automations = module.exports = (() => {
         }
     }
 
+    const deleteDraftInvoicesFromStripe = (params) => {
+        let deletedInvoice
+        try {
+            deletedInvoice = db.models.Payment.destroy({
+                where: {
+                    external_uuid: params.invoiceId
+                }
+            })
+        } catch (err) {
+            console.log(`An error ocurred while deleting invoice: ${err}`)
+        }
+        return deletedInvoice
+    }
+
     const getClientFromEmail = (params) => {
         return db.models.Client.findOne({
             where: {
@@ -146,6 +160,7 @@ const automations = module.exports = (() => {
 
     return {
         createPayment,
+        deleteDraftInvoicesFromStripe,
         getClientWithExternalId,
         getUserOrganizations,
         getOrganizationRepos,

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -29,7 +29,7 @@ const automations = module.exports = (() => {
                 }
             })
         } catch (err) {
-            console.log(`An error ocurred while deleting invoice: ${err}`)
+            console.log(`An error ocurred: ${err}`)
         }
         return deletedInvoice
     }

--- a/server.js
+++ b/server.js
@@ -143,6 +143,15 @@ app.post('/api/webhooks/invoice/updated', (req, res) => {
         res.send('payment not ready to allocate')
     }
 })
+app.post('/api/webhooks/invoice/delete', async (req, res) => {
+    const invoiceId = req.body.data.object.id
+    try {
+        await apiModules.automations.deleteDraftInvoicesFromStripe({ invoiceId })
+        res.sendStatus(200)
+    } catch (err) {
+        console.log(`An error ocurred: ${err}`)
+    }
+})
 app.post('/api/webhooks/payment_intent/succeeded', (req, res) => {
     const data = req.body.data
     try {


### PR DESCRIPTION
**Issue #409**
**Description**

A new webhook is created for deleting draft invoices from Stripe. When a draft invoice is deleted from the Stripe dashboard, it activates the webhook and goes the endpoint that was created for deleting the invoice with the external_uuid.

**Implementation proof**

https://user-images.githubusercontent.com/36824674/122448807-25f60180-cf73-11eb-94cb-c52d524e5ff5.mp4

