### PR TITLE
Refactoring webhook functions to corresponding module

### DIFF
--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -61,7 +61,6 @@ const automations = module.exports = (() => {
     }
 
     return {
-        getClientWithExternalId,
         getUserOrganizations,
         getOrganizationRepos,
     }

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -3,14 +3,6 @@ const db = require('../models')
 
 const automations = module.exports = (() => {
 
-    const getClientWithExternalId = (params) => {
-        return db.models.Client.findOne({
-            where: {
-                external_uuid: params.id
-            }
-        })
-    }
-
     const getUserOrganizations = async (params) => {
         //user organizations are the organizations that the contributor is added as a internal collaborator
         //we also add the self github contributor user for implementation details

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -20,20 +20,6 @@ const automations = module.exports = (() => {
         }
     }
 
-    const deleteDraftInvoicesFromStripe = (params) => {
-        let deletedInvoice
-        try {
-            deletedInvoice = db.models.Payment.destroy({
-                where: {
-                    external_uuid: params.invoiceId
-                }
-            })
-        } catch (err) {
-            console.log(`An error ocurred: ${err}`)
-        }
-        return deletedInvoice
-    }
-
     const getClientFromEmail = (params) => {
         return db.models.Client.findOne({
             where: {

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -1,39 +1,13 @@
-const moment = require('moment')
-
 const github = require('../handlers/github')
-const { GITHUB } = require('../config/credentials')
 const db = require('../models')
 
 const automations = module.exports = (() => {
-
-    const getClientFromEmail = (params) => {
-        return db.models.Client.findOne({
-            where: {
-                email: params.email
-            }
-        })
-    }
 
     const getClientWithExternalId = (params) => {
         return db.models.Client.findOne({
             where: {
                 external_uuid: params.id
             }
-        })
-    }
-
-    const getPaymentWithExternalId = (params) => {
-        return db.models.Payment.findOne({
-            where: {
-                external_uuid: params.id
-            },
-            raw: true,
-        })
-    }
-
-    const getPaymentWithId = (params) => {
-        return db.models.Payment.findByPk(params.id, {
-            raw: true
         })
     }
 
@@ -95,7 +69,6 @@ const automations = module.exports = (() => {
     }
 
     return {
-        createPayment,
         getClientWithExternalId,
         getUserOrganizations,
         getOrganizationRepos,

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -6,20 +6,6 @@ const db = require('../models')
 
 const automations = module.exports = (() => {
 
-    const createPayment = async ({ paymentInformation }) => {
-        const client = await getClientWithExternalId({ id: paymentInformation.customer_id })
-        if (client) {
-            return db.models.Payment.create({
-                amount: paymentInformation.amount,
-                external_uuid: paymentInformation.external_uuid,
-                date_incurred: moment(paymentInformation.date_incurred['_d']).format('YYYY-MM-DD HH:mm:ss'),
-                date_paid: paymentInformation.date_paid ? moment(paymentInformation.date_paid['_d']) : null,
-                client_id: client.id,
-                external_uuid_type: paymentInformation.external_uuid_type
-            })
-        }
-    }
-
     const getClientFromEmail = (params) => {
         return db.models.Client.findOne({
             where: {
@@ -108,50 +94,11 @@ const automations = module.exports = (() => {
         return organizations
     }
 
-    const updateDatePaidPayment = async ({ paymentInformation }) => {
-        const paymentToUpdate = {}
-        if (paymentInformation.external_uuid) {
-            Object.assign(paymentToUpdate, await getPaymentWithExternalId({ id: paymentInformation.external_uuid }))
-        } else {
-            Object.assign(paymentToUpdate, await getPaymentWithId({ id: paymentInformation.id }))
-        }
-
-        paymentToUpdate.date_paid = paymentInformation.date_paid
-        await db.models.Payment.update({
-            date_paid: moment(paymentToUpdate.date_paid, 'YYYY-MM-DD')
-        }, {
-            where: {
-                id: paymentToUpdate.id
-            }
-        })
-
-    }
-
-    const updatePaymentFromStripe = async (params) => {
-        const paymentToUpdate = await db.models.Payment.findOne({
-            where: {
-                external_uuid: params.paymentInformation.external_uuid,
-                external_uuid_type: params.paymentInformation.external_uuid_type
-            }
-        })
-        if (paymentToUpdate) {
-            if (params.paymentInformation.date_paid) {
-                updateDatePaidPayment({ paymentInformation: params.paymentInformation })
-            }
-        } else {
-            //the payment is not in the db, proceed to store it
-            createPayment({ paymentInformation: params.paymentInformation })
-        }
-    }
-
     return {
         createPayment,
-        deleteDraftInvoicesFromStripe,
         getClientWithExternalId,
         getUserOrganizations,
         getOrganizationRepos,
-        updateDatePaidPayment,
-        updatePaymentFromStripe
     }
 
 })()

--- a/api/modules/budgeting.js
+++ b/api/modules/budgeting.js
@@ -2,6 +2,20 @@ const db = require('../models');
 
 const budgeting = module.exports = (() => {
 
+    const createPayment = async ({ paymentInformation }) => {
+        const client = await getClientWithExternalId({ id: paymentInformation.customer_id })
+        if (client) {
+            return db.models.Payment.create({
+                amount: paymentInformation.amount,
+                external_uuid: paymentInformation.external_uuid,
+                date_incurred: moment(paymentInformation.date_incurred['_d']).format('YYYY-MM-DD HH:mm:ss'),
+                date_paid: paymentInformation.date_paid ? moment(paymentInformation.date_paid['_d']) : null,
+                client_id: client.id,
+                external_uuid_type: paymentInformation.external_uuid_type
+            })
+        }
+    }
+
     const deletePaymentByStripeInvoiceId = (params) => {
         let deletedPayment
         try {
@@ -15,8 +29,47 @@ const budgeting = module.exports = (() => {
         }
         return deletedPayment
     }
+
+    const updateDatePaidPayment = async ({ paymentInformation }) => {
+        const paymentToUpdate = {}
+        if (paymentInformation.external_uuid) {
+            Object.assign(paymentToUpdate, await getPaymentWithExternalId({ id: paymentInformation.external_uuid }))
+        } else {
+            Object.assign(paymentToUpdate, await getPaymentWithId({ id: paymentInformation.id }))
+        }
+
+        paymentToUpdate.date_paid = paymentInformation.date_paid
+        await db.models.Payment.update({
+            date_paid: moment(paymentToUpdate.date_paid, 'YYYY-MM-DD')
+        }, {
+            where: {
+                id: paymentToUpdate.id
+            }
+        })
+
+    }
+
+    const updatePaymentByStripeInvoiceId = async (params) => {
+        const paymentToUpdate = await db.models.Payment.findOne({
+            where: {
+                external_uuid: params.paymentInformation.external_uuid,
+                external_uuid_type: params.paymentInformation.external_uuid_type
+            }
+        })
+        if (paymentToUpdate) {
+            if (params.paymentInformation.date_paid) {
+                updateDatePaidPayment({ paymentInformation: params.paymentInformation })
+            }
+        } else {
+            //the payment is not in the db, proceed to store it
+            createPayment({ paymentInformation: params.paymentInformation })
+        }
+    }
     
     return {
-        deletePaymentByStripeInvoiceId
+        createPayment,
+        deletePaymentByStripeInvoiceId,
+        updateDatePaidPayment,
+        updatePaymentByStripeInvoiceId,
     }
 })()

--- a/api/modules/budgeting.js
+++ b/api/modules/budgeting.js
@@ -19,7 +19,7 @@ const budgeting = module.exports = (() => {
             return db.models.Payment.create({
                 amount,
                 external_uuid,
-                date_incurred: moment(date_incurred['_d']).format('YYYY-MM-DD HH:mm:ss'),
+                date_incurred: date_incurred.format('YYYY-MM-DD HH:mm:ss'),
                 date_paid: date_paid ? moment(date_paid['_d']) : null,
                 client_id: client.id,
                 external_uuid_type
@@ -79,7 +79,12 @@ const budgeting = module.exports = (() => {
     }
 
     const updatePaymentByStripeInvoiceId = async ({ paymentObjectPayload }) => {
-        const datePaidOverride = paymentObjectPayload.custom_fields[findIndex(paymentObjectPayload.custom_fields, { 'name': 'date_paid' })]
+        const datePaidOverride = paymentObjectPayload.custom_fields[
+            findIndex(
+                paymentObjectPayload.custom_fields, 
+                { 'name': 'date_paid' }
+            )
+        ]
         const paymentInformation = {
             amount: paymentObjectPayload.total,
             external_uuid: paymentObjectPayload.id,

--- a/api/modules/budgeting.js
+++ b/api/modules/budgeting.js
@@ -1,0 +1,22 @@
+const db = require('../models');
+
+const budgeting = module.exports = (() => {
+
+    const deletePaymentByStripeInvoiceId = (params) => {
+        let deletedPayment
+        try {
+            deletedPayment = db.models.Payment.destroy({
+                where: {
+                    external_uuid: params.invoiceId
+                }
+            })
+        } catch {
+            throw 'Failed deleting from database'
+        }
+        return deletedPayment
+    }
+    
+    return {
+        deletePaymentByStripeInvoiceId
+    }
+})()

--- a/api/modules/budgeting.js
+++ b/api/modules/budgeting.js
@@ -6,14 +6,23 @@ const budgeting = module.exports = (() => {
 
     const createPayment = async ({ paymentInformation }) => {
         const client = await clientManagement.getClientWithExternalId({ id: paymentInformation.customer_id })
+
+        const {
+            amount,
+            external_uuid,
+            date_incurred,
+            date_paid,
+            external_uuid_type
+        } = paymentInformation
+
         if (client) {
             return db.models.Payment.create({
-                amount: paymentInformation.amount,
-                external_uuid: paymentInformation.external_uuid,
-                date_incurred: moment(paymentInformation.date_incurred['_d']).format('YYYY-MM-DD HH:mm:ss'),
-                date_paid: paymentInformation.date_paid ? moment(paymentInformation.date_paid['_d']) : null,
+                amount,
+                external_uuid,
+                date_incurred: moment(date_incurred['_d']).format('YYYY-MM-DD HH:mm:ss'),
+                date_paid: date_paid ? moment(date_paid['_d']) : null,
                 client_id: client.id,
-                external_uuid_type: paymentInformation.external_uuid_type
+                external_uuid_type
             })
         }
     }

--- a/api/modules/budgeting.js
+++ b/api/modules/budgeting.js
@@ -30,7 +30,26 @@ const budgeting = module.exports = (() => {
         return deletedPayment
     }
 
-    const updateDatePaidPayment = async ({ paymentInformation }) => {
+    const getPaymentWithExternalId = (params) => {
+        return db.models.Payment.findOne({
+            where: {
+                external_uuid: params.id
+            },
+            raw: true,
+        })
+    }
+
+    const getPaymentWithId = (params) => {
+        return db.models.Payment.findByPk(params.id, {
+            raw: true
+        })
+    }
+
+    const updateDatePaidPayment = async ({ data }) => {
+        const paymentInformation = {
+            date_paid: data.webhooks_delivered_at,
+            external_uuid: data.id
+        }
         const paymentToUpdate = {}
         if (paymentInformation.external_uuid) {
             Object.assign(paymentToUpdate, await getPaymentWithExternalId({ id: paymentInformation.external_uuid }))
@@ -46,7 +65,6 @@ const budgeting = module.exports = (() => {
                 id: paymentToUpdate.id
             }
         })
-
     }
 
     const updatePaymentByStripeInvoiceId = async (params) => {

--- a/api/modules/budgeting.js
+++ b/api/modules/budgeting.js
@@ -1,4 +1,5 @@
 const db = require('../models');
+const moment = require('moment')
 
 const budgeting = module.exports = (() => {
 

--- a/api/modules/budgeting.js
+++ b/api/modules/budgeting.js
@@ -82,7 +82,7 @@ const budgeting = module.exports = (() => {
         const datePaidOverride = paymentObjectPayload.custom_fields[
             findIndex(
                 paymentObjectPayload.custom_fields, 
-                { 'name': 'date_paid' }
+                { name: 'date_paid' }
             )
         ]
         const paymentInformation = {

--- a/api/modules/budgeting.js
+++ b/api/modules/budgeting.js
@@ -1,10 +1,11 @@
-const db = require('../models');
+const db = require('../models')
 const moment = require('moment')
+const clientManagement = require('./clientManagement')
 
 const budgeting = module.exports = (() => {
 
     const createPayment = async ({ paymentInformation }) => {
-        const client = await getClientWithExternalId({ id: paymentInformation.customer_id })
+        const client = await clientManagement.getClientWithExternalId({ id: paymentInformation.customer_id })
         if (client) {
             return db.models.Payment.create({
                 amount: paymentInformation.amount,

--- a/api/modules/budgeting.js
+++ b/api/modules/budgeting.js
@@ -56,10 +56,10 @@ const budgeting = module.exports = (() => {
         })
     }
 
-    const updateDatePaidPayment = async ({ data }) => {
+    const updateDatePaidPayment = async ({ paymentObjectPayload }) => {
         const paymentInformation = {
-            date_paid: data.webhooks_delivered_at,
-            external_uuid: data.id
+            date_paid: paymentObjectPayload.webhooks_delivered_at,
+            external_uuid: paymentObjectPayload.id
         }
         const paymentToUpdate = {}
         if (paymentInformation.external_uuid) {
@@ -78,14 +78,14 @@ const budgeting = module.exports = (() => {
         })
     }
 
-    const updatePaymentByStripeInvoiceId = async ({ data }) => {
-        const datePaidOverride = data.custom_fields[findIndex(data.custom_fields, { 'name': 'date_paid' })]
+    const updatePaymentByStripeInvoiceId = async ({ paymentObjectPayload }) => {
+        const datePaidOverride = paymentObjectPayload.custom_fields[findIndex(paymentObjectPayload.custom_fields, { 'name': 'date_paid' })]
         const paymentInformation = {
-            amount: data.total,
-            external_uuid: data.id,
-            date_incurred: data.created,
+            amount: paymentObjectPayload.total,
+            external_uuid: paymentObjectPayload.id,
+            date_incurred: paymentObjectPayload.created,
             date_paid: datePaidOverride ? datePaidOverride.value : null,
-            customer_id: data.customer,
+            customer_id: paymentObjectPayload.customer,
             external_uuid_type: 'STRIPE',
         }
         const paymentToUpdate = await db.models.Payment.findOne({

--- a/api/modules/clientManagement.js
+++ b/api/modules/clientManagement.js
@@ -54,25 +54,33 @@ const clientManagement = module.exports = (() => {
             external_uuid: stripeCustomerObject.id,
             is_active: 1
         }
+
+        const {
+            email,
+            name,
+            currency,
+            external_uuid
+        } = clientInformation
+
         if (clientInformation.external_uuid) {
             clientToUpdate = await db.models.Client.findOne({
                 where: {
-                    external_uuid: clientInformation.external_uuid
+                    external_uuid
                 }
             })
         }
         if (clientInformation.email && (clientToUpdate === null)) {
             clientToUpdate = await db.models.Client.findOne({
                 where: {
-                    email: clientInformation.email
+                    email
                 }
             })
         }
         if (clientToUpdate) {
-            clientToUpdate.email = clientInformation.email
-            clientToUpdate.currency = clientInformation.currency
-            clientToUpdate.name = clientInformation.name
-            clientToUpdate.external_uuid = clientInformation.external_uuid
+            clientToUpdate.email = email
+            clientToUpdate.currency = currency
+            clientToUpdate.name = name
+            clientToUpdate.external_uuid = external_uuid
             await clientToUpdate.save()
         } else {
             createClient({ clientInformation })

--- a/api/modules/clientManagement.js
+++ b/api/modules/clientManagement.js
@@ -36,6 +36,14 @@ const clientManagement = module.exports = (() => {
         })
     }
 
+    const getClientWithExternalId = (params) => {
+        return db.models.Client.findOne({
+            where: {
+                external_uuid: params.id
+            }
+        })
+    }
+
     const updateClient = async ({ stripeCustomerObject }) => {
         let clientToUpdate
         const clientInformation = {
@@ -74,6 +82,7 @@ const clientManagement = module.exports = (() => {
     return {
         createClient,
         findClientWithEmail,
+        getClientWithExternalId,
         updateClient
     }
 })()

--- a/api/modules/index.js
+++ b/api/modules/index.js
@@ -1,8 +1,9 @@
 const apiModules = module.exports = (() => {
     return {
         authentication: require('./authentication'),
-        dataSyncs: require('./dataSyncs'),
         automations: require('./automations'),
-        clientManagement: require('./clientManagement')
+        budgeting: require('./budgeting'),
+        clientManagement: require('./clientManagement'),
+        dataSyncs: require('./dataSyncs')
     }
 })()

--- a/server.js
+++ b/server.js
@@ -18,7 +18,7 @@ const { SITE_ROOT } = require('./api/config/constants')
 
 const app = express()
 
-var isProduction = process.env.NODE_ENV === 'production';
+const isProduction = process.env.NODE_ENV === 'production';
 var port = isProduction ? process.env.PORT : 6001;
 
 // Serve static assets
@@ -34,7 +34,7 @@ app.get('*', function(req, res, next) {
     });
 })
 
-var whitelist = [
+const whitelist = [
     'http://localhost:8080',
     'http://localhost:3000',
     'http://localhost:4000',
@@ -46,9 +46,9 @@ var whitelist = [
     'https://trinary.setlife.tech',
     'https://trinary-staging.herokuapp.com'
 ];
-var corsOptions = {
+const corsOptions = {
     origin: function(origin, callback) {
-        var originIsWhitelisted = whitelist.indexOf(origin) !== -1;
+        const originIsWhitelisted = whitelist.indexOf(origin) !== -1;
         callback(null, originIsWhitelisted);
     },
     credentials: true,
@@ -109,11 +109,7 @@ app.get('/api/oauth-redirect', (req, res) => { //redirects to the url configured
 app.post('/api/webhooks/invoice/paid', async (req, res) => {
     const data = req.body.data.object
     try {
-        const paymentInformation = {
-            date_paid: data.webhooks_delivered_at,
-            external_uuid: data.id
-        }
-        await apiModules.budgeting.updateDatePaidPayment({ paymentInformation })
+        await apiModules.budgeting.updateDatePaidPayment({ data })
         res.send('payment updated')
     } catch (err) {
         console.log(`An error ocurred: ${err}`)

--- a/server.js
+++ b/server.js
@@ -19,7 +19,7 @@ const { SITE_ROOT } = require('./api/config/constants')
 const app = express()
 
 const isProduction = process.env.NODE_ENV === 'production';
-var port = isProduction ? process.env.PORT : 6001;
+const port = isProduction ? process.env.PORT : 6001;
 
 // Serve static assets
 app.use(express.static(__dirname + '/build'));

--- a/server.js
+++ b/server.js
@@ -107,19 +107,19 @@ app.get('/api/oauth-redirect', (req, res) => { //redirects to the url configured
 })
 
 app.post('/api/webhooks/invoice/paid', async (req, res) => {
-    const data = req.body.data.object
+    const paymentObjectPayload = req.body.data.object
     try {
-        await apiModules.budgeting.updateDatePaidPayment({ data })
+        await apiModules.budgeting.updateDatePaidPayment({ paymentObjectPayload })
         res.send('payment updated')
     } catch (err) {
         console.log(`An error ocurred: ${err}`)
     }
 })
 app.post('/api/webhooks/invoice/updated', (req, res) => {
-    const data = req.body.data.object
+    const paymentObjectPayload = req.body.data.object
     //1. see if payment is ready to allocate, if not do nothing
-    if (findIndex(data.custom_fields, { 'name': 'ready_to_allocate', 'value': 'true' }) != -1) {
-        apiModules.budgeting.updatePaymentByStripeInvoiceId({ data })
+    if (findIndex(paymentObjectPayload.custom_fields, { 'name': 'ready_to_allocate', 'value': 'true' }) != -1) {
+        apiModules.budgeting.updatePaymentByStripeInvoiceId({ paymentObjectPayload })
             .then(() => {
                 res.send('payment updated')
             })
@@ -140,12 +140,12 @@ app.post('/api/webhooks/invoice/delete', async (req, res) => {
     }
 })
 app.post('/api/webhooks/payment_intent/succeeded', (req, res) => {
-    const data = req.body.data
+    const paymentObjectPayload = req.body.data
     try {
-        if (data.status == 'succeeded') {
+        if (paymentObjectPayload.status == 'succeeded') {
             throw 'Payment not succeeded'
         }
-        apiModules.budgeting.updateDatePaidPayment({ data })
+        apiModules.budgeting.updateDatePaidPayment({ paymentObjectPayload })
         res.send('payment updated')
     } catch (err) {
         console.log(`An error ocurred: ${err}`)

--- a/server.js
+++ b/server.js
@@ -119,16 +119,7 @@ app.post('/api/webhooks/invoice/updated', (req, res) => {
     const data = req.body.data.object
     //1. see if payment is ready to allocate, if not do nothing
     if (findIndex(data.custom_fields, { 'name': 'ready_to_allocate', 'value': 'true' }) != -1) {
-        const datePaidOverride = data.custom_fields[findIndex(data.custom_fields, { 'name': 'date_paid' })]
-        const paymentInformation = {
-            amount: data.total,
-            external_uuid: data.id,
-            date_incurred: data.created,
-            date_paid: datePaidOverride ? datePaidOverride.value : null,
-            customer_id: data.customer,
-            external_uuid_type: 'STRIPE',
-        }
-        apiModules.budgeting.updatePaymentByStripeInvoiceId({ paymentInformation })
+        apiModules.budgeting.updatePaymentByStripeInvoiceId({ data })
             .then(() => {
                 res.send('payment updated')
             })
@@ -154,11 +145,7 @@ app.post('/api/webhooks/payment_intent/succeeded', (req, res) => {
         if (data.status == 'succeeded') {
             throw 'Payment not succeeded'
         }
-        const paymentInformation = {
-            date_paid: data.object.created,
-            external_uuid: data.object.invoice
-        }
-        apiModules.budgeting.updateDatePaidPayment({ paymentInformation })
+        apiModules.budgeting.updateDatePaidPayment({ data })
         res.send('payment updated')
     } catch (err) {
         console.log(`An error ocurred: ${err}`)

--- a/server.js
+++ b/server.js
@@ -146,7 +146,7 @@ app.post('/api/webhooks/invoice/updated', (req, res) => {
 app.post('/api/webhooks/invoice/delete', async (req, res) => {
     const invoiceId = req.body.data.object.id
     try {
-        await apiModules.automations.deleteDraftInvoicesFromStripe({ invoiceId })
+        await apiModules.budgeting.deletePaymentByStripeInvoiceId({ invoiceId })
         res.sendStatus(200)
     } catch (err) {
         console.log(`An error ocurred: ${err}`)

--- a/server.js
+++ b/server.js
@@ -168,7 +168,7 @@ app.post('/api/webhooks/clients', async (req, res, next) => {
         }
     } else if (webhookType === 'customer.updated' ) {
         try {
-            await apiModules.clientManagement.updateClient({ clientInformation })
+            await apiModules.clientManagement.updateClient({ stripeCustomerObject })
             res.sendStatus(200)
         } catch (err) {
             console.log(`An error ocurred: ${err}`)

--- a/server.js
+++ b/server.js
@@ -155,21 +155,12 @@ app.post('/api/webhooks/payment_intent/succeeded', (req, res) => {
 app.post('/api/webhooks/clients', async (req, res, next) => {
     const webhookPayload = req.body
     const stripeCustomerObject = webhookPayload.data.object
-
-    const clientInformation = {
-        email: stripeCustomerObject.email,
-        currency: stripeCustomerObject.currency || 'SATS',
-        name: stripeCustomerObject.name,
-        date_created: stripeCustomerObject.created,
-        external_uuid: stripeCustomerObject.id,
-        is_active: 1
-    }
     const webhookType = webhookPayload.type
 
     if (webhookType === 'customer.created') {
         try {
             await apiModules.clientManagement.createClient({
-                createFields: clientInformation
+                stripeCustomerObject
             })
             res.sendStatus(200)
         } catch (err) {

--- a/server.js
+++ b/server.js
@@ -113,7 +113,7 @@ app.post('/api/webhooks/invoice/paid', async (req, res) => {
             date_paid: data.webhooks_delivered_at,
             external_uuid: data.id
         }
-        await apiModules.automations.updateDatePaidPayment({ paymentInformation })
+        await apiModules.budgeting.updateDatePaidPayment({ paymentInformation })
         res.send('payment updated')
     } catch (err) {
         console.log(`An error ocurred: ${err}`)
@@ -132,7 +132,7 @@ app.post('/api/webhooks/invoice/updated', (req, res) => {
             customer_id: data.customer,
             external_uuid_type: 'STRIPE',
         }
-        apiModules.automations.updatePaymentFromStripe({ paymentInformation })
+        apiModules.budgeting.updatePaymentByStripeInvoiceId({ paymentInformation })
             .then(() => {
                 res.send('payment updated')
             })
@@ -162,7 +162,7 @@ app.post('/api/webhooks/payment_intent/succeeded', (req, res) => {
             date_paid: data.object.created,
             external_uuid: data.object.invoice
         }
-        apiModules.automations.updateDatePaidPayment({ paymentInformation })
+        apiModules.budgeting.updateDatePaidPayment({ paymentInformation })
         res.send('payment updated')
     } catch (err) {
         console.log(`An error ocurred: ${err}`)


### PR DESCRIPTION
**Issue #432 and #435**
**Description**

Cleaning up the server.js file so all the webhook functions are moved to its corresponding module, in this case the two modules for the existing webhooks are clientManagement and Budgeting. There are also some quick refactoring on variables that were set with var and changed to const.

- [x] Resolve all comments in: https://github.com/setlife-network/trinary/pull/432
- [x] webhook `/invoice/updated` / `updatePaymentFromStripe` to `budgeting` module
- [x] Rename `updatePaymentFromStripe` to `updatePaymentByStripeInvoiceId`
- [x] webhook `/invoice/paid` / `updateDatePaidPayment` to `budgeting` module
- [x] Create new functions as needed to keep our `server.js` file as a thin routing layer with minimal functional logic
