### PR TITLE
Fix Expected hours for MaxBudget contributors from Doesn't apply to amount/rate #412

### DIFF
--- a/src/components/ContributorTile.js
+++ b/src/components/ContributorTile.js
@@ -20,7 +20,8 @@ import { GET_ALLOCATIONS } from '../operations/queries/AllocationQueries'
 import {
     formatAmount,
     selectActiveAndUpcomingAllocations,
-    selectCurrencyInformation
+    selectCurrencyInformation,
+    estimatedHours
 } from '../scripts/selectors'
 
 const ContributorTile = (props) => {
@@ -84,6 +85,10 @@ const ContributorTile = (props) => {
                 currencyInformation: currencyInformation
             })
             const isActiveAllocation = moment.utc(a.start_date, 'x').isBefore(moment())
+            const expectedHoursMaxBudget = estimatedHours({
+                amount: a.amount / 100,
+                hourlyRate : a.rate.hourly_rate
+            })
 
             return (
                 <Grid
@@ -130,7 +135,7 @@ const ContributorTile = (props) => {
                                     <br/>
                                     {`${a.rate.total_expected_hours
                                         ? `${a.rate.total_expected_hours} h.`
-                                        : `Doesn't apply`
+                                        : `${expectedHoursMaxBudget} h.`
                                     }`}
                                 </Typography>
                             </Grid>

--- a/src/components/ContributorTile.js
+++ b/src/components/ContributorTile.js
@@ -21,7 +21,7 @@ import {
     formatAmount,
     selectActiveAndUpcomingAllocations,
     selectCurrencyInformation,
-    estimatedHours
+    getExpectedHours
 } from '../scripts/selectors'
 
 const ContributorTile = (props) => {
@@ -85,9 +85,9 @@ const ContributorTile = (props) => {
                 currencyInformation: currencyInformation
             })
             const isActiveAllocation = moment.utc(a.start_date, 'x').isBefore(moment())
-            const expectedHoursMaxBudget = estimatedHours({
-                amount: a.amount / 100,
-                hourlyRate : a.rate.hourly_rate
+            const expectedHoursMaxBudget = getExpectedHours({
+                amount: Number((a.amount / 100).toFixed(2)),
+                hourlyRate: a.rate.hourly_rate
             })
 
             return (

--- a/src/scripts/selectors.js
+++ b/src/scripts/selectors.js
@@ -42,14 +42,14 @@ export const formatAmount = (props) => {
         }
     )
 }
-export const estimatedHours = (props) => {
+export const getExpectedHours = (props) => {
     const {
         amount,
         hourlyRate
     } = props
 
-    return(
-        Math.round(amount/parseInt(hourlyRate))
+    return (
+        Math.round(amount / Number(hourlyRate))
     )
 }
 export const getAllocatedContributors = ({ allocations }) => {

--- a/src/scripts/selectors.js
+++ b/src/scripts/selectors.js
@@ -42,6 +42,16 @@ export const formatAmount = (props) => {
         }
     )
 }
+export const estimatedHours = (props) => {
+    const {
+        amount,
+        hourlyRate
+    } = props
+
+    return(
+        Math.round(amount/parseInt(hourlyRate))
+    )
+}
 export const getAllocatedContributors = ({ allocations }) => {
     const contributorsAllocated = []
     allocations.map(a => {


### PR DESCRIPTION
A new function was added to `selectors.js` named **estimatedHours**
This function has 2 props **amount** and **hourlyRate** and returns the division rounded of `amount/hourlyRate`.

In `ContributorTile.js` **expectedHoursMaxBudget** calls the function **estimatedHours**  to get the value and show it for the MaxBudget Contributors 

![image](https://user-images.githubusercontent.com/86666889/125697791-dbc7db37-02b8-40fe-a13c-01b9eff04bcc.png)