### PR TITLE
Inactive/Active clients on Home and Edit Client

### DIFF
--- a/api/handlers/stripe.js
+++ b/api/handlers/stripe.js
@@ -35,7 +35,7 @@ const stripe = module.exports = (() => {
     }
 
     const pushUpdatedClient = async (params) => {
-        const client = await findClientWithEmail(params.updateFields)
+        const client = await apiModules.clientManagement.findClientWithEmail(params.updateFields)
         const stripe_uuid = client.external_uuid
         if (stripe_uuid) {
             return stripeClient.customers.update(

--- a/api/schema/resolvers/ClientResolver.js
+++ b/api/schema/resolvers/ClientResolver.js
@@ -45,7 +45,7 @@ module.exports = {
         getInactiveClients: (root, args, { models }) => {
             return models.Client.findAll( {
                 where: {
-                    is_active: 2
+                    is_active: false
                 }
             })
         },
@@ -59,7 +59,7 @@ module.exports = {
         getInactiveClientsCount: (root, args, { models }) => {
             return models.Client.count({
                 where: {
-                    is_active: 2
+                    is_active: false
                 }
             })
         }

--- a/api/schema/resolvers/ClientResolver.js
+++ b/api/schema/resolvers/ClientResolver.js
@@ -45,7 +45,7 @@ module.exports = {
         getInactiveClients: (root, args, { models }) => {
             return models.Client.findAll( {
                 where: {
-                    is_active: false
+                    is_active: 2
                 }
             })
         },
@@ -59,7 +59,7 @@ module.exports = {
         getInactiveClientsCount: (root, args, { models }) => {
             return models.Client.count({
                 where: {
-                    is_active: false
+                    is_active: 2
                 }
             })
         }

--- a/api/schema/resolvers/ClientResolver.js
+++ b/api/schema/resolvers/ClientResolver.js
@@ -42,6 +42,13 @@ module.exports = {
         getClients: (root, args, { models }) => {
             return models.Client.findAll()
         },
+        getInactiveClients: (root, args, { models }) => {
+            return models.Client.findAll( {
+                where: {
+                    is_active: false
+                }
+            })
+        },
         getActiveClientsCount: (root, args, { models }) => {
             return models.Client.count({
                 where: {

--- a/api/schema/resolvers/ClientResolver.js
+++ b/api/schema/resolvers/ClientResolver.js
@@ -48,6 +48,13 @@ module.exports = {
                     is_active: true
                 }
             })
+        },
+        getInactiveClientsCount: (root, args, { models }) => {
+            return models.Client.count({
+                where: {
+                    is_active: false
+                }
+            })
         }
     },
     Mutation: {

--- a/api/schema/resolvers/ClientResolver.js
+++ b/api/schema/resolvers/ClientResolver.js
@@ -42,6 +42,13 @@ module.exports = {
         getClients: (root, args, { models }) => {
             return models.Client.findAll()
         },
+        getActiveClients: (root, args, { models }) => {
+            return models.Client.findAll( {
+                where: {
+                    is_active: true
+                }
+            })
+        },
         getInactiveClients: (root, args, { models }) => {
             return models.Client.findAll( {
                 where: {

--- a/api/schema/types/ClientType.js
+++ b/api/schema/types/ClientType.js
@@ -35,6 +35,7 @@ module.exports = gql`
     type Query {
         getClientById(id: Int!): Client
         getClients: [Client]
+        getInactiveClients: [Client]
         getActiveClientsCount: Int!
         getInactiveClientsCount: Int!
     }

--- a/api/schema/types/ClientType.js
+++ b/api/schema/types/ClientType.js
@@ -35,6 +35,7 @@ module.exports = gql`
     type Query {
         getClientById(id: Int!): Client
         getClients: [Client]
+        getActiveClients: [Client]
         getInactiveClients: [Client]
         getActiveClientsCount: Int!
         getInactiveClientsCount: Int!

--- a/api/schema/types/ClientType.js
+++ b/api/schema/types/ClientType.js
@@ -36,6 +36,7 @@ module.exports = gql`
         getClientById(id: Int!): Client
         getClients: [Client]
         getActiveClientsCount: Int!
+        getInactiveClientsCount: Int!
     }
 
     type Mutation {

--- a/src/components/ClientEditDialog.js
+++ b/src/components/ClientEditDialog.js
@@ -10,11 +10,13 @@ import {
     Grid,
     MenuItem,
     Select,
-    TextField
+    TextField,
+    FormGroup,
 } from '@material-ui/core/'
 
 import { UPDATE_CLIENT } from '../operations/mutations/ClientMutations'
 import { CURRENCIES } from '../constants'
+import Switch from '@material-ui/core/Switch';
 
 const ClientEditDialog = (props) => {
 
@@ -29,6 +31,7 @@ const ClientEditDialog = (props) => {
     const [clientName, setClientName] = useState(client.name)
     const [clientEmail, setClientEmail] = useState(client.email)
     const [clientCurrency, setClientCurrency] = useState(client.currency)
+    const [clientIsActive, setClientIsActive] = useState(client.is_active)
     const [disableEdit, setDisableEdit] = useState(true)
 
     const onEdit = async () => {
@@ -41,6 +44,9 @@ const ClientEditDialog = (props) => {
         }
         if (clientCurrency) {
             clientInfoToEdit['currency'] = clientCurrency
+        }
+        if (clientIsActive) {
+            clientInfoToEdit['is_active'] = clientIsActive
         }
         updateClient({
             variables: clientInfoToEdit
@@ -63,12 +69,26 @@ const ClientEditDialog = (props) => {
     useEffect(() => {
         if (!clientName || !clientCurrency) {
             setDisableEdit(true)
-        } else if (clientName == client.name && clientCurrency == client.currency && clientEmail == client.email) {
+        } else if (
+            clientName == client.name &&
+            clientCurrency == client.currency &&
+            clientEmail == client.email &&
+            clientIsActive == client.is_active
+        ) {
             setDisableEdit(true)
         } else {
             setDisableEdit(false)
         }
     })
+
+    const handleChange = (event) => {
+        setState({ ...state, [event.target.name]: event.target.checked })
+        setClientIsActive(event.target.checked)
+    }
+
+    const [state, setState] = React.useState({
+        checkedA: client.is_active,
+    });
 
     return (
         <Dialog className='ClientEditDialog' onClose={onClose} open={open}>
@@ -106,7 +126,7 @@ const ClientEditDialog = (props) => {
                             </Box>
                         </Grid>
                         <Grid item xs={12} lg={5}>
-                            <Box width={1}>
+                            <Box my={2}>
                                 <Select
                                     name='Currency'
                                     defaultValue={client.currency}
@@ -118,6 +138,22 @@ const ClientEditDialog = (props) => {
                                 <FormHelperText>
                                     {`Select currency`}
                                 </FormHelperText>
+                            </Box>
+                        </Grid>
+                        <Grid item xs={12} lg={5}>
+                            <Box my={2}>
+                                <Grid component='label' container alignItems='center' spacing={1}>
+                                    <Grid item>Inactive</Grid>
+                                    <Grid item>
+                                        <Switch
+                                            checked={state.checkedA}
+                                            onChange={handleChange}
+                                            name='checkedA'
+                                            color='primary'
+                                        />
+                                    </Grid>
+                                    <Grid item>Active</Grid>
+                                </Grid>
                             </Box>
                         </Grid>
                         <Grid item xs={12}>

--- a/src/components/ClientEditDialog.js
+++ b/src/components/ClientEditDialog.js
@@ -12,11 +12,11 @@ import {
     Select,
     TextField,
     FormGroup,
+    Switch
 } from '@material-ui/core/'
 
 import { UPDATE_CLIENT } from '../operations/mutations/ClientMutations'
 import { CURRENCIES } from '../constants'
-import Switch from '@material-ui/core/Switch';
 
 const ClientEditDialog = (props) => {
 
@@ -47,7 +47,6 @@ const ClientEditDialog = (props) => {
         }
         clientInfoToEdit['is_active'] = clientIsActive
 
-        console.log(clientInfoToEdit)
         updateClient({
             variables: clientInfoToEdit
         })
@@ -87,7 +86,7 @@ const ClientEditDialog = (props) => {
     }
 
     const [state, setState] = React.useState({
-        checkedA: client.is_active,
+        clientActiveSwitch: client.is_active,
     });
 
     return (
@@ -146,7 +145,7 @@ const ClientEditDialog = (props) => {
                                     <Grid item>Inactive</Grid>
                                     <Grid item>
                                         <Switch
-                                            checked={state.checkedA}
+                                            checked={state.clientActiveSwitch}
                                             onChange={handleChange}
                                             name='checkedA'
                                             color='primary'

--- a/src/components/ClientEditDialog.js
+++ b/src/components/ClientEditDialog.js
@@ -45,9 +45,9 @@ const ClientEditDialog = (props) => {
         if (clientCurrency) {
             clientInfoToEdit['currency'] = clientCurrency
         }
-        if (clientIsActive) {
-            clientInfoToEdit['is_active'] = clientIsActive
-        }
+        clientInfoToEdit['is_active'] = clientIsActive
+
+        console.log(clientInfoToEdit)
         updateClient({
             variables: clientInfoToEdit
         })

--- a/src/components/ClientsList.js
+++ b/src/components/ClientsList.js
@@ -8,13 +8,13 @@ import ClientTile from './ClientTile'
 import ClientsEmptyState from './ClientsEmptyState'
 import ClientsEmptyStateStripe from './ClientsEmptyStateStripe'
 import LoadingProgress from './LoadingProgress'
-import { GET_CLIENTS } from '../operations/queries/ClientQueries'
+import { GET_ACTIVE_CLIENTS } from '../operations/queries/ClientQueries'
 import { HAS_VALID_STRIPE_CREDENTIALS } from '../operations/queries/ConfigQueries';
 
 const ClientsList = (props) => {
     const history = useHistory()
     const { loading: loadingS, error: errorS, data: dataStripe } = useQuery(HAS_VALID_STRIPE_CREDENTIALS);
-    const { loading, error, data } = useQuery(GET_CLIENTS);
+    const { loading, error, data } = useQuery(GET_ACTIVE_CLIENTS);
 
     const renderClientTiles = (clients) => {
         return clients.map(c => {
@@ -32,7 +32,7 @@ const ClientsList = (props) => {
     if (loading) return <LoadingProgress/>
     if (error) return `Error! ${error.message}`;
 
-    const clients = orderBy(data.getClients, 'is_active', 'desc')
+    const clients = orderBy(data.getActiveClients, 'is_active', 'desc')
 
     return (
         <>

--- a/src/components/InactiveClientListManager.js
+++ b/src/components/InactiveClientListManager.js
@@ -8,16 +8,9 @@ import Switch from '@material-ui/core/Switch';
 
 import LoadingProgress from './LoadingProgress'
 import { GET_INACTIVE_CLIENTS_COUNT } from '../operations/queries/ClientQueries'
+import InactiveClientsList from "./InactiveClientsList";
 
 const InactiveClientListManager = (props) => {
-
-    const handleChange = (event) => {
-        setState({ ...state, [event.target.name]: event.target.checked })
-    }
-
-    const [state, setState] = React.useState({
-        checkedA: false,
-    });
 
     const { loading, error, data } = useQuery(GET_INACTIVE_CLIENTS_COUNT);
 
@@ -31,46 +24,11 @@ const InactiveClientListManager = (props) => {
         >
             {
                 data.getInactiveClientsCount != 0
-                ? (
-                        <FormGroup>
-                            <FormControlLabel
-                                control={<Switch checked={state.checkedA} onChange={handleChange} name='checkedA' />}
-                                label='Show inactive clients'
-                            />
-                        </FormGroup>
+                    ? (
+                       <InactiveClientsList />
                     ) : ( false )
             }
-            <Grid
-                container
-                direction='row'
-                justify='space-between'
-                alignItems='flex-end'
-            >
-                {
-                    state.checkedA == true
-                        ? (
-                            <Grid item xs={8} sm={6} md={4}>
-                                <Box
-                                    bgcolor='primary.black'
-                                    color='primary.light'
-                                    borderRadius='borderRadius'
-                                    px={2}
-                                    px-lg={5}
-                                    py={1}
-                                >
-                                    {
-                                        `${data.getInactiveClientsCount} inactive ${data.getInactiveClientsCount == 1
-                                            ? 'client'
-                                            : 'clients'
-                                        }`
-                                    }
-                                </Box>
-                            </Grid>
-                        ) : (
-                            false
-                        )
-                }
-            </Grid>
+
         </Box>
 
     )

--- a/src/components/InactiveClientListManager.js
+++ b/src/components/InactiveClientListManager.js
@@ -25,7 +25,7 @@ const InactiveClientListManager = (props) => {
             {
                 data.getInactiveClientsCount != 0
                     ? (
-                       <InactiveClientsList />
+                        <InactiveClientsList />
                     ) : ( false )
             }
 

--- a/src/components/InactiveClientListManager.js
+++ b/src/components/InactiveClientListManager.js
@@ -1,0 +1,79 @@
+import React from 'react'
+import Grid from '@material-ui/core/Grid'
+import Box from '@material-ui/core/Box';
+import { useQuery } from '@apollo/client';
+import FormGroup from '@material-ui/core/FormGroup';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Switch from '@material-ui/core/Switch';
+
+import LoadingProgress from './LoadingProgress'
+import { GET_INACTIVE_CLIENTS_COUNT } from '../operations/queries/ClientQueries'
+
+const InactiveClientListManager = (props) => {
+
+    const handleChange = (event) => {
+        setState({ ...state, [event.target.name]: event.target.checked })
+    }
+
+    const [state, setState] = React.useState({
+        checkedA: false,
+    });
+
+    const { loading, error, data } = useQuery(GET_INACTIVE_CLIENTS_COUNT);
+
+    if (loading) return <LoadingProgress/>
+    if (error) return `Error! ${error.message}`;
+    return (
+        <Box
+            mb={3}
+            mx={1}
+            className='ClientListManager'
+        >
+            {
+                data.getInactiveClientsCount != 0
+                ? (
+                        <FormGroup>
+                            <FormControlLabel
+                                control={<Switch checked={state.checkedA} onChange={handleChange} name='checkedA' />}
+                                label='Show inactive clients'
+                            />
+                        </FormGroup>
+                    ) : ( false )
+            }
+            <Grid
+                container
+                direction='row'
+                justify='space-between'
+                alignItems='flex-end'
+            >
+                {
+                    state.checkedA == true
+                        ? (
+                            <Grid item xs={8} sm={6} md={4}>
+                                <Box
+                                    bgcolor='primary.black'
+                                    color='primary.light'
+                                    borderRadius='borderRadius'
+                                    px={2}
+                                    px-lg={5}
+                                    py={1}
+                                >
+                                    {
+                                        `${data.getInactiveClientsCount} inactive ${data.getInactiveClientsCount == 1
+                                            ? 'client'
+                                            : 'clients'
+                                        }`
+                                    }
+                                </Box>
+                            </Grid>
+                        ) : (
+                            false
+                        )
+                }
+            </Grid>
+        </Box>
+
+    )
+}
+
+export default InactiveClientListManager

--- a/src/components/InactiveClientListManager.js
+++ b/src/components/InactiveClientListManager.js
@@ -8,12 +8,12 @@ import Switch from '@material-ui/core/Switch';
 
 import LoadingProgress from './LoadingProgress'
 import { GET_INACTIVE_CLIENTS_COUNT } from '../operations/queries/ClientQueries'
-import InactiveClientsList from "./InactiveClientsList";
+import InactiveClientsList from './InactiveClientsList'
 
 const InactiveClientListManager = (props) => {
 
     const { loading, error, data } = useQuery(GET_INACTIVE_CLIENTS_COUNT);
-
+    console.log(data)
     if (loading) return <LoadingProgress/>
     if (error) return `Error! ${error.message}`;
     return (

--- a/src/components/InactiveClientListManager.js
+++ b/src/components/InactiveClientListManager.js
@@ -1,10 +1,6 @@
 import React from 'react'
-import Grid from '@material-ui/core/Grid'
 import Box from '@material-ui/core/Box';
 import { useQuery } from '@apollo/client';
-import FormGroup from '@material-ui/core/FormGroup';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Switch from '@material-ui/core/Switch';
 
 import LoadingProgress from './LoadingProgress'
 import { GET_INACTIVE_CLIENTS_COUNT } from '../operations/queries/ClientQueries'
@@ -13,7 +9,7 @@ import InactiveClientsList from './InactiveClientsList'
 const InactiveClientListManager = (props) => {
 
     const { loading, error, data } = useQuery(GET_INACTIVE_CLIENTS_COUNT);
-    console.log(data)
+
     if (loading) return <LoadingProgress/>
     if (error) return `Error! ${error.message}`;
     return (
@@ -24,9 +20,8 @@ const InactiveClientListManager = (props) => {
         >
             {
                 data.getInactiveClientsCount != 0
-                    ? (
-                        <InactiveClientsList />
-                    ) : ( false )
+                    ? <InactiveClientsList />
+                    : null
             }
 
         </Box>

--- a/src/components/InactiveClientsList.js
+++ b/src/components/InactiveClientsList.js
@@ -16,7 +16,6 @@ const InactiveClientsList = (props) => {
     const history = useHistory()
     const { loading, error, data } = useQuery(GET_INACTIVE_CLIENTS);
 
-
     const handleChange = (event) => {
         setState({ ...state, [event.target.name]: event.target.checked })
     }

--- a/src/components/InactiveClientsList.js
+++ b/src/components/InactiveClientsList.js
@@ -14,19 +14,28 @@ import Box from '@material-ui/core/Box'
 
 const InactiveClientsList = (props) => {
     const history = useHistory()
-    const { loading, error, data } = useQuery(GET_INACTIVE_CLIENTS);
+    const {
+        loading: loadingInactiveClient,
+        error: errorInactiveClient,
+        data: dataInactiveClient
+    } = useQuery(GET_INACTIVE_CLIENTS);
 
     const handleChange = (event) => {
         setState({ ...state, [event.target.name]: event.target.checked })
     }
 
     const [state, setState] = React.useState({
-        checkedA: false,
+        inactiveClientsCheck: false,
     });
-    const { loading: loadingInactive , error: errorInactive, data: dataInactive } = useQuery(GET_INACTIVE_CLIENTS_COUNT);
 
-    if (loadingInactive) return <LoadingProgress/>
-    if (errorInactive) return `Error! ${errorInactive.message}`;
+    const {
+        loading: loadingInactiveClientsCount,
+        error: errorInactiveClientsCount,
+        data: dataInactiveClientsCount
+    } = useQuery(GET_INACTIVE_CLIENTS_COUNT);
+
+    if (loadingInactiveClientsCount) return <LoadingProgress/>
+    if (errorInactiveClientsCount) return `Error! ${errorInactiveClientsCount.message}`;
 
     const renderClientTiles = (clients) => {
         return clients.map(c => {
@@ -41,9 +50,9 @@ const InactiveClientsList = (props) => {
         })
     }
 
-    if (loading) return <LoadingProgress/>
-    if (error) return `Error! ${error.message}`;
-    const clients = orderBy(data.getInactiveClients, 'is_active', 'desc')
+    if (loadingInactiveClient) return <LoadingProgress/>
+    if (errorInactiveClient) return `Error! ${errorInactiveClient.message}`;
+    const clients = orderBy(dataInactiveClient.getInactiveClients, 'is_active', 'desc')
 
     return (
         <>
@@ -52,9 +61,9 @@ const InactiveClientsList = (props) => {
                     control=
                         {
                             <Switch
-                                checked={state.checkedA}
+                                checked={state.inactiveClientsCheck}
                                 onChange={handleChange}
-                                name='checkedA'
+                                name='inactiveClientsCheck'
                             />
                         }
                     label='Show inactive clients'
@@ -67,7 +76,7 @@ const InactiveClientsList = (props) => {
                 alignItems='flex-end'
             >
                 {
-                    state.checkedA == true
+                    state.inactiveClientsCheck == true
                         ? (
                             <Grid item xs={12} sm={6} md={4}>
                                 <Box
@@ -79,20 +88,22 @@ const InactiveClientsList = (props) => {
                                     py={1}
                                 >
                                     {
-                                        `${dataInactive.getInactiveClientsCount} inactive ${dataInactive.getInactiveClientsCount == 1
+                                        `${dataInactiveClientsCount.getInactiveClientsCount} inactive ${dataInactiveClientsCount.getInactiveClientsCount == 1
                                             ? 'client'
                                             : 'clients'
                                         }`
                                     }
                                 </Box>
                             </Grid>
-                        ) : (
-                            false
-                        )
+                        ) : null
                 }
                 <Grid container>
                     {
-                        state.checkedA ? clients.length != 0 ? renderClientTiles(clients) : false : false
+                        state.inactiveClientsCheck
+                            ? clients.length != 0
+                                ? renderClientTiles(clients)
+                                : null
+                            : null
                     }
                 </Grid>
             </Grid>

--- a/src/components/InactiveClientsList.js
+++ b/src/components/InactiveClientsList.js
@@ -1,0 +1,104 @@
+import React from 'react'
+import { useHistory } from 'react-router-dom';
+import { useQuery } from '@apollo/client';
+import { Grid } from '@material-ui/core'
+import { orderBy } from 'lodash'
+
+import ClientTile from './ClientTile'
+import LoadingProgress from './LoadingProgress'
+import {GET_INACTIVE_CLIENTS, GET_INACTIVE_CLIENTS_COUNT} from '../operations/queries/ClientQueries'
+import FormGroup from '@material-ui/core/FormGroup'
+import FormControlLabel from '@material-ui/core/FormControlLabel'
+import Switch from '@material-ui/core/Switch'
+import Box from '@material-ui/core/Box'
+
+const InactiveClientsList = (props) => {
+    const history = useHistory()
+    const { loading, error, data } = useQuery(GET_INACTIVE_CLIENTS);
+
+
+    const handleChange = (event) => {
+        setState({ ...state, [event.target.name]: event.target.checked })
+    }
+
+    const [state, setState] = React.useState({
+        checkedA: false,
+    });
+    const { loading: loadingInactive , error: errorInactive, data: dataInactive } = useQuery(GET_INACTIVE_CLIENTS_COUNT);
+
+    if (loadingInactive) return <LoadingProgress/>
+    if (errorInactive) return `Error! ${errorInactive.message}`;
+
+    const renderClientTiles = (clients) => {
+        return clients.map(c => {
+            return (
+                <Grid item xs={12} sm={6} lg={4}>
+                    <ClientTile
+                        client={c}
+                        history={history}
+                    />
+                </Grid>
+            )
+        })
+    }
+
+    if (loading) return <LoadingProgress/>
+    if (error) return `Error! ${error.message}`;
+    const clients = orderBy(data.getInactiveClients, 'is_active', 'desc')
+
+    return (
+        <>
+            <FormGroup>
+                <FormControlLabel
+                    control=
+                        {
+                            <Switch
+                                checked={state.checkedA}
+                                onChange={handleChange}
+                                name='checkedA'
+                            />
+                        }
+                    label='Show inactive clients'
+                />
+            </FormGroup>
+            <Grid
+                container
+                direction='row'
+                justify='space-between'
+                alignItems='flex-end'
+            >
+                {
+                    state.checkedA == true
+                        ? (
+                            <Grid item xs={12} sm={6} md={4}>
+                                <Box
+                                    bgcolor='primary.black'
+                                    color='primary.light'
+                                    borderRadius='borderRadius'
+                                    px={2}
+                                    px-lg={5}
+                                    py={1}
+                                >
+                                    {
+                                        `${dataInactive.getInactiveClientsCount} inactive ${dataInactive.getInactiveClientsCount == 1
+                                            ? 'client'
+                                            : 'clients'
+                                        }`
+                                    }
+                                </Box>
+                            </Grid>
+                        ) : (
+                            false
+                        )
+                }
+                <Grid container>
+                    {
+                        state.checkedA ? clients.length != 0 ? renderClientTiles(clients) : false : false
+                    }
+                </Grid>
+            </Grid>
+        </>
+    )
+}
+
+export default InactiveClientsList

--- a/src/components/InactiveClientsList.js
+++ b/src/components/InactiveClientsList.js
@@ -6,7 +6,7 @@ import { orderBy } from 'lodash'
 
 import ClientTile from './ClientTile'
 import LoadingProgress from './LoadingProgress'
-import {GET_INACTIVE_CLIENTS, GET_INACTIVE_CLIENTS_COUNT} from '../operations/queries/ClientQueries'
+import { GET_INACTIVE_CLIENTS, GET_INACTIVE_CLIENTS_COUNT } from '../operations/queries/ClientQueries'
 import FormGroup from '@material-ui/core/FormGroup'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import Switch from '@material-ui/core/Switch'

--- a/src/operations/mutations/ClientMutations.js
+++ b/src/operations/mutations/ClientMutations.js
@@ -17,19 +17,20 @@ export const CREATE_CLIENT = gql`
 `
 
 export const UPDATE_CLIENT = gql`
-    mutation UpdateClient($id: Int!, $name: String, $email: String, $currency: String) {
+    mutation UpdateClient($id: Int!, $name: String, $email: String, $currency: String, $is_active: Boolean) {
         updateClientById(
             id: $id,
             updateFields: {
             name: $name,
             email: $email,
             currency: $currency,
-            is_active: true
+            is_active: $is_active
         }){
             id,
             name,
             email,
-            currency
+            currency,
+            is_active
         }
     }
 `

--- a/src/operations/queries/ClientQueries.js
+++ b/src/operations/queries/ClientQueries.js
@@ -72,6 +72,17 @@ export const GET_CLIENTS = gql`
     }
 `
 
+export const GET_ACTIVE_CLIENTS = gql`
+    query Clients {
+        getActiveClients {
+            id
+            name
+            currency
+            is_active
+        }
+    }
+`
+
 export const GET_INACTIVE_CLIENTS = gql`
     query Clients {
         getInactiveClients {

--- a/src/operations/queries/ClientQueries.js
+++ b/src/operations/queries/ClientQueries.js
@@ -6,6 +6,12 @@ export const GET_ACTIVE_CLIENTS_COUNT = gql`
     }
 `
 
+export const GET_INACTIVE_CLIENTS_COUNT = gql`
+    query Clients {
+        getInactiveClientsCount
+    }
+`
+
 export const GET_CLIENT_INFO = gql`
     query Client($id: Int!) {
         getClientById(id: $id){

--- a/src/operations/queries/ClientQueries.js
+++ b/src/operations/queries/ClientQueries.js
@@ -72,6 +72,17 @@ export const GET_CLIENTS = gql`
     }
 `
 
+export const GET_INACTIVE_CLIENTS = gql`
+    query Clients {
+        getInactiveClients {
+            id
+            name
+            currency
+            is_active
+        }
+    }
+`
+
 export const GET_CLIENT_PAYMENTS = gql`
 query ClientPayments($clientId: Int!) {
     getClientById(id: $clientId){

--- a/src/pages/ClientsListPage.js
+++ b/src/pages/ClientsListPage.js
@@ -3,7 +3,8 @@ import { Grid } from '@material-ui/core'
 
 import ClientsListManager from '../components/ClientsListManager'
 import ClientsList from '../components/ClientsList'
-import InactiveClientListManager from "../components/InactiveClientListManager"
+import InactiveClientListManager from '../components/InactiveClientListManager'
+import InactiveClientsList from '../components/InactiveClientsList'
 
 class ClientListPage extends React.Component {
     render() {

--- a/src/pages/ClientsListPage.js
+++ b/src/pages/ClientsListPage.js
@@ -3,6 +3,7 @@ import { Grid } from '@material-ui/core'
 
 import ClientsListManager from '../components/ClientsListManager'
 import ClientsList from '../components/ClientsList'
+import InactiveClientListManager from "../components/InactiveClientListManager"
 
 class ClientListPage extends React.Component {
     render() {
@@ -18,6 +19,7 @@ class ClientListPage extends React.Component {
                         <Grid container>
                             <ClientsList />
                         </Grid>
+                        <InactiveClientListManager />
                     </Grid>
                 </Grid>
             </div>


### PR DESCRIPTION
**Issue #413**
**Description**

On the home view we now have the ability to show Inactive Clients, if there are no inactive clients the option won't show. 
On the edit client view, we have the ability to edit the `is_active` status of a client.

Additionally, on the home view was fixed that it used to show all clients, no matter if they were active or inactive. Now they are separated.