### PR TITLE
UI refresh after adding, editing or deleting data.

### DIFF
--- a/src/components/ClientProjectsList.js
+++ b/src/components/ClientProjectsList.js
@@ -14,6 +14,7 @@ const ClientProjectsList = ({
 }) => {
 
     const { loading, error, data, networkStatus } = useQuery(GET_CLIENT_INFO, {
+        fetchPolicy: "cache-and-network",
         variables: { id: Number(clientId) }
     })
 

--- a/src/components/ClientProjectsList.js
+++ b/src/components/ClientProjectsList.js
@@ -14,7 +14,7 @@ const ClientProjectsList = ({
 }) => {
 
     const { loading, error, data, networkStatus } = useQuery(GET_CLIENT_INFO, {
-        fetchPolicy: "cache-and-network",
+        fetchPolicy: 'cache-and-network',
         variables: { id: Number(clientId) }
     })
 

--- a/src/components/ClientsList.js
+++ b/src/components/ClientsList.js
@@ -14,7 +14,7 @@ import { HAS_VALID_STRIPE_CREDENTIALS } from '../operations/queries/ConfigQuerie
 const ClientsList = (props) => {
     const history = useHistory()
     const { loading: loadingS, error: errorS, data: dataStripe } = useQuery(HAS_VALID_STRIPE_CREDENTIALS);
-    const { loading, error, data } = useQuery(GET_CLIENTS, {
+    const { loading, error, data } = useQuery(GET_ACTIVE_CLIENTS, {
         fetchPolicy: 'cache-and-network'
     });
 

--- a/src/components/ClientsList.js
+++ b/src/components/ClientsList.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { useHistory } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import { Grid } from '@material-ui/core'
@@ -14,7 +14,9 @@ import { HAS_VALID_STRIPE_CREDENTIALS } from '../operations/queries/ConfigQuerie
 const ClientsList = (props) => {
     const history = useHistory()
     const { loading: loadingS, error: errorS, data: dataStripe } = useQuery(HAS_VALID_STRIPE_CREDENTIALS);
-    const { loading, error, data } = useQuery(GET_CLIENTS);
+    const { loading, error, data } = useQuery(GET_CLIENTS, {
+        fetchPolicy: "cache-and-network"
+    });
 
     const renderClientTiles = (clients) => {
         return clients.map(c => {

--- a/src/components/ClientsListManager.js
+++ b/src/components/ClientsListManager.js
@@ -17,7 +17,9 @@ const ClientListManager = (props) => {
         history.push('/client/add')
     }
 
-    const { loading, error, data } = useQuery(GET_ACTIVE_CLIENTS_COUNT);
+    const { loading, error, data } = useQuery(GET_ACTIVE_CLIENTS_COUNT, {
+        fetchPolicy: "cache-and-network"
+    });
 
     if (loading) return <LoadingProgress/>
     if (error) return `Error! ${error.message}`;

--- a/src/components/ClientsListManager.js
+++ b/src/components/ClientsListManager.js
@@ -18,7 +18,7 @@ const ClientListManager = (props) => {
     }
 
     const { loading, error, data } = useQuery(GET_ACTIVE_CLIENTS_COUNT, {
-        fetchPolicy: "cache-and-network"
+        fetchPolicy: 'cache-and-network'
     });
 
     if (loading) return <LoadingProgress/>

--- a/src/components/HomeProjects.js
+++ b/src/components/HomeProjects.js
@@ -11,7 +11,9 @@ const HomeProjects = ({
     history
 }) => {
 
-    const { loading, error, data } = useQuery(GET_ALL_PROJECTS);
+    const { loading, error, data } = useQuery(GET_ALL_PROJECTS, {
+        fetchPolicy: "cache-and-network"
+    });
 
     if (loading) return <LoadingProgress/>
     if (error) return `Error! ${error.message}`;

--- a/src/components/HomeProjects.js
+++ b/src/components/HomeProjects.js
@@ -12,7 +12,7 @@ const HomeProjects = ({
 }) => {
 
     const { loading, error, data } = useQuery(GET_ALL_PROJECTS, {
-        fetchPolicy: "cache-and-network"
+        fetchPolicy: 'cache-and-network'
     });
 
     if (loading) return <LoadingProgress/>

--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -46,7 +46,7 @@ const PaymentTile = (props) => {
         error: errorPaymentAllocations,
         data: dataPaymentAllocations
     } = useQuery(GET_PAYMENT_ALLOCATIONS, {
-        fetchPolicy: "cache-and-network",
+        fetchPolicy: 'cache-and-network',
         variables: { paymentId: Number(payment.id) }
     })
     const {
@@ -54,7 +54,7 @@ const PaymentTile = (props) => {
         error: errorTotalAllocated,
         data: dataTotalAllocated
     } = useQuery(GET_PAYMENT_TOTAL_ALLOCATED, {
-        fetchPolicy: "cache-and-network",
+        fetchPolicy: 'cache-and-network',
         variables: { paymentId: Number(payment.id) }
     })
 

--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -46,6 +46,7 @@ const PaymentTile = (props) => {
         error: errorPaymentAllocations,
         data: dataPaymentAllocations
     } = useQuery(GET_PAYMENT_ALLOCATIONS, {
+        fetchPolicy: "cache-and-network",
         variables: { paymentId: Number(payment.id) }
     })
     const {
@@ -53,6 +54,7 @@ const PaymentTile = (props) => {
         error: errorTotalAllocated,
         data: dataTotalAllocated
     } = useQuery(GET_PAYMENT_TOTAL_ALLOCATED, {
+        fetchPolicy: "cache-and-network",
         variables: { paymentId: Number(payment.id) }
     })
 

--- a/src/components/ProjectPayments.js
+++ b/src/components/ProjectPayments.js
@@ -31,7 +31,7 @@ const ProjectPayments = (props) => {
     const history = useHistory()
 
     const { loading, error, data } = useQuery(GET_PROJECT_PAYMENTS, {
-        fetchPolicy: "cache-and-network",
+        fetchPolicy: 'cache-and-network',
         variables: {
             id: Number(projectId)
         }
@@ -41,7 +41,7 @@ const ProjectPayments = (props) => {
         error: errorProjectAllocations,
         loading: loadingProjectAllocations,
     } = useQuery(GET_PROJECT_CONTRIBUTOR_ALLOCATIONS, {
-        fetchPolicy: "cache-and-network",
+        fetchPolicy: 'cache-and-network',
         variables: {
             id: Number(projectId),
         }

--- a/src/components/ProjectPayments.js
+++ b/src/components/ProjectPayments.js
@@ -31,6 +31,7 @@ const ProjectPayments = (props) => {
     const history = useHistory()
 
     const { loading, error, data } = useQuery(GET_PROJECT_PAYMENTS, {
+        fetchPolicy: "cache-and-network",
         variables: {
             id: Number(projectId)
         }
@@ -40,8 +41,9 @@ const ProjectPayments = (props) => {
         error: errorProjectAllocations,
         loading: loadingProjectAllocations,
     } = useQuery(GET_PROJECT_CONTRIBUTOR_ALLOCATIONS, {
+        fetchPolicy: "cache-and-network",
         variables: {
-            id: Number(projectId)
+            id: Number(projectId),
         }
     })
 

--- a/src/components/ProjectPaymentsSummary.js
+++ b/src/components/ProjectPaymentsSummary.js
@@ -21,7 +21,7 @@ const ProjectPaymentsSummary = (props) => {
         error: errorPaymentsSummary,
         loading: loadingPaymentsSummary
     } = useQuery(GET_PROJECT_PAYMENTS_SUMMARY, {
-        fetchPolicy: "cache-and-network",
+        fetchPolicy: 'cache-and-network',
         variables: {
             id: Number(project.id)
         }

--- a/src/components/ProjectPaymentsSummary.js
+++ b/src/components/ProjectPaymentsSummary.js
@@ -21,6 +21,7 @@ const ProjectPaymentsSummary = (props) => {
         error: errorPaymentsSummary,
         loading: loadingPaymentsSummary
     } = useQuery(GET_PROJECT_PAYMENTS_SUMMARY, {
+        fetchPolicy: "cache-and-network",
         variables: {
             id: Number(project.id)
         }

--- a/src/components/ProjectProposedAllocationsTile.js
+++ b/src/components/ProjectProposedAllocationsTile.js
@@ -32,7 +32,7 @@ const ProjectProposedAllocationsTile = (props) => {
         loading: loadingTotalProposed
     } = useQuery(GET_PROJECT_TOTAL_PROPOSED, {
         variables: {
-            id: project.id
+            id: project.id,
         }
     })
 

--- a/src/components/ProjectsListManager.js
+++ b/src/components/ProjectsListManager.js
@@ -21,7 +21,7 @@ const ProjectsListManager = ({
     const { loading, error, data } = useQuery(GET_ACTIVE_PROJECTS_COUNT, {
         variables: {
             clientId: clientId ? Number(clientId) : null,
-            fetchPolicy: "cache-and-network"
+            fetchPolicy: 'cache-and-network'
         }
     })
     const pathname = window.location.pathname

--- a/src/components/ProjectsListManager.js
+++ b/src/components/ProjectsListManager.js
@@ -20,7 +20,8 @@ const ProjectsListManager = ({
     }
     const { loading, error, data } = useQuery(GET_ACTIVE_PROJECTS_COUNT, {
         variables: {
-            clientId: clientId ? Number(clientId) : null
+            clientId: clientId ? Number(clientId) : null,
+            fetchPolicy: "cache-and-network"
         }
     })
     const pathname = window.location.pathname


### PR DESCRIPTION
**Issue #453**
Now when we add a client, project, or allocation the UI will update without having to refresh.

The problem was caused because when there is an _useQuery_  with Apollo, there is a [fetch policy](https://www.apollographql.com/docs/react/data/queries/#setting-a-fetch-policy), by default this policy will only check the cache and show only the store data on it without querying the GraphSQL server. To fix this issue we have to specify what policy do we want for the query.

For example:
```
const { loading, error, data } = useQuery(GET_DOGS, {
  fetchPolicy: "cache-and-network"
});
```

If we use _cache-and-network_ policy 
> Apollo Client executes the full query against both the cache and your GraphQL server. The query automatically updates if the result of the server-side query modifies cached fields.