### PR TITLE
Allocation bugs fixes

### DIFF
--- a/src/components/AllocationAddForm.js
+++ b/src/components/AllocationAddForm.js
@@ -341,7 +341,7 @@ const AllocationAddForm = (props) => {
             ? dataProjectContributors.allocations
             : null
     const payments = dataClientPayments
-        ? [...dataClientPayments.getProjectById.client.payments, { amount: null, date_paid: null }]
+        ? [...dataClientPayments.getProjectById.client.payments, { amount: null, date_paid: null }].sort((a, b) => b.date_incurred - a.date_incurred)
         : [null]
     const clientCurrency = (
         dataClientPayments

--- a/src/components/AllocationAddForm.js
+++ b/src/components/AllocationAddForm.js
@@ -341,7 +341,10 @@ const AllocationAddForm = (props) => {
             ? dataProjectContributors.allocations
             : null
     const payments = dataClientPayments
-        ? [...dataClientPayments.getProjectById.client.payments, { amount: null, date_paid: null }].sort((a, b) => b.date_incurred - a.date_incurred)
+        ? [...dataClientPayments.getProjectById.client.payments, { 
+            amount: null,
+            date_paid: null 
+        }].sort((a, b) => b.date_incurred - a.date_incurred)
         : [null]
     const clientCurrency = (
         dataClientPayments

--- a/src/components/AllocationOverview.js
+++ b/src/components/AllocationOverview.js
@@ -225,7 +225,8 @@ const AllocationOverview = (props) => {
     }
     
     const editButtonDisabled = (
-        updatedAllocationRate.total_amount <= 0 
+        updatedAllocationRate.total_amount <= 0 ||
+        updatedAllocationRate.hourly_rate <= 0
     )
 
     return (

--- a/src/components/AllocationOverview.js
+++ b/src/components/AllocationOverview.js
@@ -213,9 +213,11 @@ const AllocationOverview = (props) => {
     if (errorAllocation || errorClientPayments) return `Error`
 
     const { getAllocationById: allocation } = dataAllocation
-    const payments = [null]
-    if (clientPayments) {
-        payments.unshift(...clientPayments.payments)
+    const payments = dataClientPayments
+        ? [...dataClientPayments.getClientById.payments, { amount: null, date_paid: null }].sort((a, b) => b.date_incurred - a.date_incurred)
+        : [null]
+    if (payments) {
+        payments.pop();
     }
 
     if (!contributorAllocation) {
@@ -223,8 +225,7 @@ const AllocationOverview = (props) => {
     }
     
     const editButtonDisabled = (
-        updatedAllocationRate.total_amount == allocationInfo.amount &&
-        updatedAllocationRate.hourly_rate == allocationInfo.rate.hourly_rate
+        updatedAllocationRate.total_amount <= 0 
     )
 
     return (
@@ -259,11 +260,16 @@ const AllocationOverview = (props) => {
                     startDate={updatedAllocationStartDate}
                 />
                 <Box mt={1}>
-                    <Grid container>
-                        <Grid item xs={3}>
+                    <Grid 
+                        container 
+                        justify='space-between'
+                        style={{ textAlign: 'center' }}
+                    >
+                        <Grid item xs={12} sm={3}>
                             <Button
                                 variant='contained'
                                 color='primary'
+                                className='edit-delete'
                                 disabled={editButtonDisabled}
                                 onClick={() => handleUpdateAllocation({
                                     allocation: contributorAllocation,
@@ -278,9 +284,10 @@ const AllocationOverview = (props) => {
                                 {'Edit'}
                             </Button>
                         </Grid>
-                        <Grid item>
+                        <Grid item xs={12} sm={3}>
                             <Button
                                 color='primary'
+                                className='edit-delete'
                                 onClick={() => setOpenDeleteAllocation(true)}
                             >
                                 <DeleteOutlinedIcon color='primary'/>

--- a/src/components/AllocationOverview.js
+++ b/src/components/AllocationOverview.js
@@ -229,7 +229,8 @@ const AllocationOverview = (props) => {
     }
     
     const editButtonDisabled = (
-        updatedAllocationRate.total_amount <= 0 
+        updatedAllocationRate.total_amount == allocationInfo.amount &&
+        updatedAllocationRate.hourly_rate == allocationInfo.rate.hourly_rate
     )
 
     return (

--- a/src/components/AllocationOverview.js
+++ b/src/components/AllocationOverview.js
@@ -214,10 +214,10 @@ const AllocationOverview = (props) => {
 
     const { getAllocationById: allocation } = dataAllocation
     const payments = dataClientPayments
-        ? [...dataClientPayments.getClientById.payments, { amount: null, date_paid: null }].sort((a, b) => b.date_incurred - a.date_incurred)
+        ? [...dataClientPayments.getClientById.payments].sort((a, b) => b.date_incurred - a.date_incurred)
         : [null]
-    if (payments) {
-        payments.pop();
+    if (payments.length) {
+        payments.push(null)
     }
 
     if (!contributorAllocation) {

--- a/src/components/AllocationOverview.js
+++ b/src/components/AllocationOverview.js
@@ -213,9 +213,13 @@ const AllocationOverview = (props) => {
     if (errorAllocation || errorClientPayments) return `Error`
 
     const { getAllocationById: allocation } = dataAllocation
+    
     const payments = dataClientPayments
-        ? [...dataClientPayments.getClientById.payments].sort((a, b) => b.date_incurred - a.date_incurred)
+        ? [
+            ...dataClientPayments.getClientById.payments
+        ].sort((a, b) => b.date_incurred - a.date_incurred)
         : [null]
+
     if (payments.length) {
         payments.push(null)
     }
@@ -225,8 +229,7 @@ const AllocationOverview = (props) => {
     }
     
     const editButtonDisabled = (
-        updatedAllocationRate.total_amount <= 0 ||
-        updatedAllocationRate.hourly_rate <= 0
+        updatedAllocationRate.total_amount <= 0 
     )
 
     return (

--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -14,6 +14,7 @@ import {
 import DeleteOutlinedIcon from '@material-ui/icons/DeleteOutlined';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import MonetizationOnIcon from '@material-ui/icons/MonetizationOn'
+import EditIcon from '@material-ui/icons/Edit';
 
 import AllocationAddForm from './AllocationAddForm'
 import AllocationOverview from './AllocationOverview'
@@ -122,7 +123,7 @@ const PaymentTile = (props) => {
                 <Box mb={3} className='PaymentTile'>
                     <Grid
                         container
-                        onClick={() => handleAllocationClicked({ value: true, allocation: a })}
+                        className='cursor-grid'
                     >
                         <Grid items xs={10} >
                             <Typography color='secondary' variant='caption'>
@@ -145,6 +146,14 @@ const PaymentTile = (props) => {
                             <Typography color='secondary' variant='caption'>
                                 {`Ends ${moment.utc(end_date, 'x').format('MM/DD/YYYY')} `}
                             </Typography>
+                        </Grid>
+                        <Grid item xs={12}>
+                            <Button 
+                                fullWidth
+                                onClick={() => handleAllocationClicked({ value: true, allocation: a })}
+                            >
+                                <EditIcon color='secondary' />
+                            </Button>
                         </Grid>
                     </Grid>
                 </Box>

--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -122,37 +122,40 @@ const PaymentTile = (props) => {
             })
 
             return (
-                <Box mb={3} className='PaymentTile'>
+                <Box 
+                    mb={3} 
+                    className='PaymentTile' 
+                >
                     <Grid
                         container
                         className='payments-grid'
+                        onClick={() => handleAllocationClicked({ value: true, allocation: a })}
                     >
                         <Grid items xs={6}>
-                            <Typography color='secondary' variant='caption'>
+                            <Typography color='secondary' variant='caption' className='animation-effect-left'>
                                 {`${contributor.name}`}
                             </Typography>
                         </Grid>
                         <Grid className='edit-button-grid' item xs={6} align='right'>
                             <EditIcon 
                                 color='primary' 
-                                onClick={() => handleAllocationClicked({ value: true, allocation: a })}
                                 className='edit-button' 
                             />
                         </Grid>
                         <Grid items xs={12}>
-                            <Typography color='secondary' variant='caption'>
-                                {`${currencyInformation['symbol']}${rate.hourly_rate}/hr (
+                            <Typography color='secondary' variant='caption' className='animation-effect-left'>
+                                {`${currencyInformation['symbol']} ${rate.hourly_rate}/hr (
                                     ${rate.type == 'monthly_rate' ? 'monthly rate' : 'max budget'}
                                 )`}
                             </Typography>
                         </Grid>
                         <Grid item xs={6}>
-                            <Typography color='secondary' variant='caption'>
+                            <Typography color='secondary' variant='caption' className='animation-effect-left'>
                                 {`${paymentAmount}`}
                             </Typography>
                         </Grid>
                         <Grid item xs={6} align='right'>
-                            <Typography color='secondary' variant='caption'>
+                            <Typography color='secondary' variant='caption' className='animation-effect-right'>
                                 {`Ends ${moment.utc(end_date, 'x').format('MM/DD/YYYY')} `}
                             </Typography>
                         </Grid>

--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -125,37 +125,41 @@ const PaymentTile = (props) => {
                 <Box mb={3} className='PaymentTile'>
                     <Grid
                         container
-                        className='cursor-grid'
+                        className='payments-grid'
                     >
-                        <Grid items xs={10} >
+                        <Grid items xs={6}>
                             <Typography color='secondary' variant='caption'>
                                 {`${contributor.name}`}
                             </Typography>
                         </Grid>
-                        <Grid item xs={2} align='right'>
-                            <Typography color='secondary' variant='caption'>
-                                {`${paymentAmount}`}
-                            </Typography>
+                        <Grid item xs={6} align='right'>
+                            {/* <Button 
+                                className='edit-button' 
+                                onClick={() => handleAllocationClicked({ value: true, allocation: a })}
+                            > */}
+                            <EditIcon 
+                                color='primary' 
+                                onClick={() => handleAllocationClicked({ value: true, allocation: a })}
+                                className='edit-button' 
+                            />
+                            {/* </Button> */}
                         </Grid>
-                        <Grid items xs={7}>
+                        <Grid items xs={12}>
                             <Typography color='secondary' variant='caption'>
                                 {`${currencyInformation['symbol']}${rate.hourly_rate}/hr (
                                     ${rate.type == 'monthly_rate' ? 'monthly rate' : 'max budget'}
                                 )`}
                             </Typography>
                         </Grid>
-                        <Grid item xs={5} align='right'>
+                        <Grid item xs={6}>
+                            <Typography color='secondary' variant='caption'>
+                                {`${paymentAmount}`}
+                            </Typography>
+                        </Grid>
+                        <Grid item xs={6} align='right'>
                             <Typography color='secondary' variant='caption'>
                                 {`Ends ${moment.utc(end_date, 'x').format('MM/DD/YYYY')} `}
                             </Typography>
-                        </Grid>
-                        <Grid item xs={12}>
-                            <Button 
-                                fullWidth
-                                onClick={() => handleAllocationClicked({ value: true, allocation: a })}
-                            >
-                                <EditIcon color='secondary' />
-                            </Button>
                         </Grid>
                     </Grid>
                 </Box>

--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -132,17 +132,12 @@ const PaymentTile = (props) => {
                                 {`${contributor.name}`}
                             </Typography>
                         </Grid>
-                        <Grid item xs={6} align='right'>
-                            {/* <Button 
-                                className='edit-button' 
-                                onClick={() => handleAllocationClicked({ value: true, allocation: a })}
-                            > */}
+                        <Grid className='edit-button-grid' item xs={6} align='right'>
                             <EditIcon 
                                 color='primary' 
                                 onClick={() => handleAllocationClicked({ value: true, allocation: a })}
                                 className='edit-button' 
                             />
-                            {/* </Button> */}
                         </Grid>
                         <Grid items xs={12}>
                             <Typography color='secondary' variant='caption'>

--- a/src/styles/AllocationOverview.scss
+++ b/src/styles/AllocationOverview.scss
@@ -1,0 +1,20 @@
+.AllocationOverview {
+
+}
+
+@media screen and (min-width: $sm) {
+    .AllocationOverview {
+        .edit-delete {
+            width: 70%;
+        }
+    }
+}
+
+@media screen and (max-width: $sm){
+    .AllocationOverview {
+        .edit-delete {
+            width: 100%;
+            margin-top: 1rem;
+        }
+    }
+}

--- a/src/styles/AllocationOverview.scss
+++ b/src/styles/AllocationOverview.scss
@@ -1,20 +1,15 @@
 .AllocationOverview {
-
+    .edit-delete {
+        width: 100%;
+        margin-top: 1rem;
+    }
 }
 
 @media screen and (min-width: $sm) {
     .AllocationOverview {
         .edit-delete {
             width: 70%;
-        }
-    }
-}
-
-@media screen and (max-width: $sm){
-    .AllocationOverview {
-        .edit-delete {
-            width: 100%;
-            margin-top: 1rem;
+            margin-top: 0;
         }
     }
 }

--- a/src/styles/PaymentTile.scss
+++ b/src/styles/PaymentTile.scss
@@ -1,29 +1,40 @@
-.PaymentTile {
+@use "@material/animation";
 
+.PaymentTile {
     .disabled-tile {
         background-color: $white !important;
     }
-    .MuiAccordionSummary-root.Mui-disabled{
+    .MuiAccordionSummary-root.Mui-disabled {
         opacity: 1 !important;
     }
 }
 
 @media screen and (min-width: $sm) {
     .PaymentTile {
-        .edit-button{
+        @keyframes fade-in{
+            from{
+                transform: translate(-80px);
+                opacity: 0;
+            }
+        }
+        .edit-button {
             display: none;
         }
-        .payments-grid{
-            transition: all 0.5s;
+        .edit-button-grid {
+            height: 1rem;
+        }
+        .payments-grid {
+            transition: all 175ms;
             &:hover{
+                padding-left: 0.5rem;
+                padding-right: 0.5rem;
+                border-radius: 0.3rem;
+                transition: all 175ms;
                 .edit-button{
                     display: inline-flex;
-                    transition: all 0.5s;
                     cursor: pointer;
                 }
-                padding: 0.5rem;
-                box-shadow: rgba(0, 0, 0, 0.25) 0px 54px 55px, rgba(0, 0, 0, 0.12) 0px -12px 30px, rgba(0, 0, 0, 0.12) 0px 4px 6px, rgba(0, 0, 0, 0.17) 0px 12px 13px, rgba(0, 0, 0, 0.09) 0px -3px 5px;
-                border-radius: 0.5rem;
+                box-shadow: rgba(0, 0, 0, 0.25) 0px 0px 1px, rgba(0, 0, 0, 0.12) 0px 1px 1px, rgba(0, 0, 0, 0.12) 0px 1px 10px, rgba(0, 0, 0, 0.17) 0px 1px 10px, rgba(0, 0, 0, 0.09) 0px 1px 1px;
             }
         }
     }

--- a/src/styles/PaymentTile.scss
+++ b/src/styles/PaymentTile.scss
@@ -7,3 +7,25 @@
         opacity: 1 !important;
     }
 }
+
+@media screen and (min-width: $sm) {
+    .PaymentTile {
+        .edit-button{
+            display: none;
+        }
+        .payments-grid{
+            transition: all 0.5s;
+            &:hover{
+                .edit-button{
+                    display: inline-flex;
+                    transition: all 0.5s;
+                    cursor: pointer;
+                }
+                padding: 0.5rem;
+                box-shadow: rgba(0, 0, 0, 0.25) 0px 54px 55px, rgba(0, 0, 0, 0.12) 0px -12px 30px, rgba(0, 0, 0, 0.12) 0px 4px 6px, rgba(0, 0, 0, 0.17) 0px 12px 13px, rgba(0, 0, 0, 0.09) 0px -3px 5px;
+                border-radius: 0.5rem;
+            }
+        }
+    }
+}
+

--- a/src/styles/PaymentTile.scss
+++ b/src/styles/PaymentTile.scss
@@ -7,32 +7,34 @@
     .MuiAccordionSummary-root.Mui-disabled {
         opacity: 1 !important;
     }
+    .edit-button {
+        height: 1rem;
+        margin-top: 0.2rem;
+    }
+    .edit-button-grid {
+        height: 1rem;
+    }
+    .animation-effect-left{
+        margin-left: 0.2rem;
+    }
+    .animation-effect-right{
+        margin-right: 0.2rem;
+    }
 }
 
 @media screen and (min-width: $sm) {
     .PaymentTile {
-        @keyframes fade-in{
-            from{
-                transform: translate(-80px);
-                opacity: 0;
-            }
-        }
         .edit-button {
             display: none;
-        }
-        .edit-button-grid {
-            height: 1rem;
         }
         .payments-grid {
             transition: all 175ms;
             &:hover{
-                padding-left: 0.5rem;
-                padding-right: 0.5rem;
                 border-radius: 0.3rem;
                 transition: all 175ms;
+                cursor: pointer;
                 .edit-button{
                     display: inline-flex;
-                    cursor: pointer;
                 }
                 box-shadow: rgba(0, 0, 0, 0.25) 0px 0px 1px, rgba(0, 0, 0, 0.12) 0px 1px 1px, rgba(0, 0, 0, 0.12) 0px 1px 10px, rgba(0, 0, 0, 0.17) 0px 1px 10px, rgba(0, 0, 0, 0.09) 0px 1px 1px;
             }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -36,6 +36,7 @@ code {
 
 //Components
 @import './AllocationAddForm.scss';
+@import './AllocationOverview.scss';
 @import './EditAllocationRate.scss';
 @import './EmptyState.scss';
 @import './Header.scss';


### PR DESCRIPTION
**Issue #411**
When you add an allocation, payments are sorted by **Date Incurred**
![image](https://user-images.githubusercontent.com/86666889/126665538-de6d0954-5045-42ce-afac-1cf991ca84c4.png)

There is a new **Edit Button** in allocations instead of having to click the allocation to edit it.
I would like some feedback on this one if the button looks good in there or if it should be placed somewhere else.
![image](https://user-images.githubusercontent.com/86666889/126666840-d0a23117-e72e-4cc9-b436-b0bb1c0d5a77.png)

The Edit Button will be only disabled if the total amount or the hourly rate is less or equals 0
The Edit and Delete buttons now have space in between and are responsive.
**Computer size**
![image](https://user-images.githubusercontent.com/86666889/126667087-4a64485c-e079-4ff3-8e27-0b92fc063671.png)

**Mobile Size**
![image](https://user-images.githubusercontent.com/86666889/126667162-e10a112f-efa9-48d1-917b-0b480f51822b.png)
