### PR TITLE
Header with fixed height 

### DIFF
--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -5,8 +5,7 @@ import {
     AppBar,
     Box,
     Grid,
-    Typography,
-    makeStyles
+    Typography
 } from '@material-ui/core'
 import withWidth, { isWidthUp } from '@material-ui/core/withWidth'
 import { split } from 'lodash'
@@ -16,20 +15,8 @@ import { LOGO_URL, SMALL_LOGO_URL } from '../constants'
 import { capitalizeWord, matchTitlePage } from '../scripts/selectors'
 import { pageName } from '../reactivities/variables'
 
-const useStyles = makeStyles((theme) => ({
-    title: {
-        margin: '12px',
-        color: '#009BAD',
-        fontWeight: 'bold',
-        [theme.breakpoints.down('sm')]: {
-            fontSize: '1rem'
-        }
-    }
-}));
-
 const Navigation = (props) => {
 
-    const classes = useStyles()
     const history = useHistory()
     const redirectToHome = () => {
         history.push('/')
@@ -64,7 +51,7 @@ const Navigation = (props) => {
                     <Grid item xs={8} sm={6}>
                         <Typography 
                             variant='h5' 
-                            className={classes.title}
+                            className='navigation-title'
                             noWrap
                         >
                             {capitalizeWord({

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -4,7 +4,9 @@ import { useReactiveVar } from '@apollo/client'
 import {
     AppBar,
     Box,
-    Grid
+    Grid,
+    Typography,
+    makeStyles
 } from '@material-ui/core'
 import withWidth, { isWidthUp } from '@material-ui/core/withWidth'
 import { split } from 'lodash'
@@ -14,8 +16,20 @@ import { LOGO_URL, SMALL_LOGO_URL } from '../constants'
 import { capitalizeWord, matchTitlePage } from '../scripts/selectors'
 import { pageName } from '../reactivities/variables'
 
+const useStyles = makeStyles((theme) => ({
+    title: {
+        margin: '12px',
+        color: '#009BAD',
+        fontWeight: 'bold',
+        [theme.breakpoints.down('sm')]: {
+            fontSize: '1rem'
+        }
+    }
+}));
+
 const Navigation = (props) => {
 
+    const classes = useStyles()
     const history = useHistory()
     const redirectToHome = () => {
         history.push('/')
@@ -48,11 +62,15 @@ const Navigation = (props) => {
                         </Box>
                     </Grid>
                     <Grid item xs={8} sm={6}>
-                        <h2 className='navigation-title'>
+                        <Typography 
+                            variant='h5' 
+                            className={classes.title}
+                            noWrap
+                        >
                             {capitalizeWord({
                                 word: locationTitle.title || optionalLocationTitle
                             })}
-                        </h2>
+                        </Typography>
                     </Grid>
                 </Grid>
             </AppBar>

--- a/src/styles/Navigation.scss
+++ b/src/styles/Navigation.scss
@@ -3,10 +3,6 @@
         max-height: 16px;
         cursor: pointer;
     }
-    .navigation-title {
-        margin: 12px;
-        color: $dark-blue;
-    }
 }
 
 @media screen and (min-width: $sm) {

--- a/src/styles/Navigation.scss
+++ b/src/styles/Navigation.scss
@@ -3,12 +3,21 @@
         max-height: 16px;
         cursor: pointer;
     }
+    .navigation-title {
+        margin: 12px;
+        color: $dark-blue;
+        font-weight: bold;
+        font-size: 1rem;
+    }
 }
 
 @media screen and (min-width: $sm) {
     .Navigation {
         .icon-image {
             max-height: 25px;
+        }
+        .navigation-title {
+            font-size: 1.5rem
         }
     }
 }


### PR DESCRIPTION
**Issue #473**
The header was fixed so it won't overflow to a second line.

In the file `Navigation.js` the _h2_ tag was changed for a _Typography_ component because Typography uses a prop named noWrap that works as follows.
>If true, the text will not wrap, but instead will truncate with a text overflow ellipsis.
Note that text overflow can only happen with block or inline-block level elements (the element needs to have a width in order to overflow).

**The following image shows how the header will look in a Mobile Device**
![image](https://user-images.githubusercontent.com/86666889/126705050-e4106409-e5cd-41df-bc8d-b938d39f67ac.png)