### PR TITLE
Separated queries for orgs and repos

### DIFF
--- a/api/handlers/github.js
+++ b/api/handlers/github.js
@@ -58,25 +58,20 @@ const github = module.exports = (() => {
         const octokit = new Octokit({
             auth: params.auth_key
         })
-        let res
-        if (params.itsOrganization) {
-            console.log('org')
-            res = await octokit.repos.listForOrg({
+        const res = 
+        params.isOrganization
+            ? await octokit.repos.listForOrg({ 
                 org: params.organizationName,
                 per_page: 100,
                 sort: 'updated',
                 direction: 'desc',
             })
-        } else {
-            console.log('user')
-            res = await octokit.repos.listForUser({
+            : await octokit.repos.listForUser({
                 username: params.organizationName,
                 per_page: 100,
                 sort: 'updated',
                 direction: 'desc',
             })
-        }
-        
         if (res.status == 200) {
             return res.data
         } else {

--- a/api/handlers/github.js
+++ b/api/handlers/github.js
@@ -58,8 +58,8 @@ const github = module.exports = (() => {
         const octokit = new Octokit({
             auth: params.auth_key
         })
-        const res = await octokit.repos.listForOrg({
-            org: params.organizationName,
+        const res = await octokit.repos.listForUser({
+            username: params.organizationName,
             per_page: 100,
             sort: 'updated',
             direction: 'desc',

--- a/api/handlers/github.js
+++ b/api/handlers/github.js
@@ -58,8 +58,7 @@ const github = module.exports = (() => {
         const octokit = new Octokit({
             auth: params.auth_key
         })
-        const res = 
-        params.isOrganization
+        const res = params.isOrganization
             ? await octokit.repos.listForOrg({ 
                 org: params.organizationName,
                 per_page: 100,

--- a/api/handlers/github.js
+++ b/api/handlers/github.js
@@ -58,8 +58,8 @@ const github = module.exports = (() => {
         const octokit = new Octokit({
             auth: params.auth_key
         })
-        const res = await octokit.repos.listForAuthenticatedUser({
-            affiliation: ['owner'],
+        const res = await octokit.repos.listForOrg({
+            org: params.organizationName,
             per_page: 100,
             sort: 'updated',
             direction: 'desc',

--- a/api/handlers/github.js
+++ b/api/handlers/github.js
@@ -58,12 +58,24 @@ const github = module.exports = (() => {
         const octokit = new Octokit({
             auth: params.auth_key
         })
-        const res = await octokit.repos.listForUser({
-            username: params.organizationName,
-            per_page: 100,
-            sort: 'updated',
-            direction: 'desc',
-        })
+        let res
+        if (params.itsOrganization) {
+            console.log('org')
+            res = await octokit.repos.listForOrg({
+                org: params.organizationName,
+                per_page: 100,
+                sort: 'updated',
+                direction: 'desc',
+            })
+        } else {
+            console.log('user')
+            res = await octokit.repos.listForUser({
+                username: params.organizationName,
+                per_page: 100,
+                sort: 'updated',
+                direction: 'desc',
+            })
+        }
         
         if (res.status == 200) {
             return res.data

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -34,7 +34,8 @@ const automations = module.exports = (() => {
             auth_key: params.auth_key
         })
         const repos = await github.fetchRepos({
-            auth_key: params.auth_key
+            auth_key: params.auth_key,
+            organizationName: params.organizationName
         })
         console.log('organizations')
         console.log(organizations.length)
@@ -44,9 +45,6 @@ const automations = module.exports = (() => {
             const organizationRepos = []
             repos.map(r => {
                 console.log(r)
-                if (o.name == 'otech47') {
-                    console.log(r.owner.login)
-                }
                 if (r.owner.login == o.name) {
                     organizationRepos.push({
                         id: r.id,

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -33,9 +33,17 @@ const automations = module.exports = (() => {
         const organizations = await getUserOrganizations({
             auth_key: params.auth_key
         })
+
+        let itsOrganization = false
+
+        if (organizations[0].name != params.organizationName) { // Check if its an org or user
+            itsOrganization = true
+        }
+
         const repos = await github.fetchRepos({
             auth_key: params.auth_key,
-            organizationName: params.organizationName
+            organizationName: params.organizationName,
+            itsOrganization
         })
         console.log('organizations')
         console.log(organizations.length)

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -33,10 +33,8 @@ const automations = module.exports = (() => {
         const organizations = await getUserOrganizations({
             auth_key: params.auth_key
         })
-        const isOrganization = 
-            organizations[0].name != params.organizationName
-                ? true
-                : false
+        const isOrganization = organizations[0].name != params.organizationName
+        
         const repos = await github.fetchRepos({
             auth_key: params.auth_key,
             organizationName: params.organizationName,

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -41,21 +41,18 @@ const automations = module.exports = (() => {
         console.log(organizations.length)
         console.log('repos')
         console.log(repos.length)
-        organizations.map(async o => {
-            const organizationRepos = []
-            repos.map(r => {
-                console.log(r)
-                if (r.owner.login == o.name) {
-                    organizationRepos.push({
-                        id: r.id,
-                        name: r.name,
-                        githubUrl: r.html_url,
-                    })
-                }
-            })
-            o.repos = organizationRepos
+        const organizationRepos = []
+        repos.map(r => {
+            console.log(r)
+            if (r.owner.login == params.organizationName) {
+                organizationRepos.push({
+                    id: r.id,
+                    name: r.name,
+                    githubUrl: r.html_url,
+                })
+            }
         })
-        return organizations
+        return organizationRepos
     }
 
     return {

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -33,25 +33,17 @@ const automations = module.exports = (() => {
         const organizations = await getUserOrganizations({
             auth_key: params.auth_key
         })
-
-        let itsOrganization = false
-
-        if (organizations[0].name != params.organizationName) { // Check if its an org or user
-            itsOrganization = true
-        }
-
+        const isOrganization = 
+            organizations[0].name != params.organizationName
+                ? true
+                : false
         const repos = await github.fetchRepos({
             auth_key: params.auth_key,
             organizationName: params.organizationName,
-            itsOrganization
+            isOrganization
         })
-        console.log('organizations')
-        console.log(organizations.length)
-        console.log('repos')
-        console.log(repos.length)
         const organizationRepos = []
         repos.map(r => {
-            console.log(r)
             if (r.owner.login == params.organizationName) {
                 organizationRepos.push({
                     id: r.id,

--- a/api/schema/resolvers/ContributorResolver.js
+++ b/api/schema/resolvers/ContributorResolver.js
@@ -98,12 +98,12 @@ module.exports = {
             })
             return contributorOrganizations
         },
-        getGithubRepos: async (root, { contributorId, organizationName }, { cookies, models }) => {
+        getGithubRepos: async (root, { organizationName }, { cookies, models }) => {
             const contributor = (
                 await models.Contributor.findByPk(
                     cookies.userSession
                         ? cookies.userSession
-                        : contributorId
+                        : organizationName
                 )
             )
             const contributorOrganizations = await apiModules.automations.getOrganizationRepos({

--- a/api/schema/resolvers/ContributorResolver.js
+++ b/api/schema/resolvers/ContributorResolver.js
@@ -96,11 +96,9 @@ module.exports = {
             const contributorOrganizations = await apiModules.automations.getUserOrganizations({
                 auth_key: contributor.github_access_token
             })
-            console.log('pendiente')
-            console.log(contributorOrganizations)
             return contributorOrganizations
         },
-        getGithubRepos: async (root, { contributorId }, { cookies, models }) => {
+        getGithubRepos: async (root, { contributorId, organizationName }, { cookies, models }) => {
             const contributor = (
                 await models.Contributor.findByPk(
                     cookies.userSession
@@ -109,7 +107,8 @@ module.exports = {
                 )
             )
             const contributorOrganizations = await apiModules.automations.getOrganizationRepos({
-                auth_key: contributor.github_access_token
+                auth_key: contributor.github_access_token,
+                organizationName: organizationName
             })
             return contributorOrganizations
         }

--- a/api/schema/resolvers/ContributorResolver.js
+++ b/api/schema/resolvers/ContributorResolver.js
@@ -93,6 +93,21 @@ module.exports = {
                         : contributorId
                 )
             )
+            const contributorOrganizations = await apiModules.automations.getUserOrganizations({
+                auth_key: contributor.github_access_token
+            })
+            console.log('pendiente')
+            console.log(contributorOrganizations)
+            return contributorOrganizations
+        },
+        getGithubRepos: async (root, { contributorId }, { cookies, models }) => {
+            const contributor = (
+                await models.Contributor.findByPk(
+                    cookies.userSession
+                        ? cookies.userSession
+                        : contributorId
+                )
+            )
             const contributorOrganizations = await apiModules.automations.getOrganizationRepos({
                 auth_key: contributor.github_access_token
             })

--- a/api/schema/types/ContributorType.js
+++ b/api/schema/types/ContributorType.js
@@ -44,6 +44,12 @@ module.exports = gql`
         id: Int!
         avatar: String
         name: String
+    }
+    
+    type ContributorRepos {
+        id: Int!
+        avatar: String
+        name: String
         repos: [githubRepo]
     }
 
@@ -63,6 +69,7 @@ module.exports = gql`
         getContributorById(id: Int!): Contributor
         getContributors: [Contributor]
         getGithubOrganizations(contributorId: Int): [ContributorOrganizations]
+        getGithubRepos(contributorId: Int):  [ContributorRepos]
     }
 
     type Mutation {

--- a/api/schema/types/ContributorType.js
+++ b/api/schema/types/ContributorType.js
@@ -50,10 +50,10 @@ module.exports = gql`
         id: Int!
         avatar: String
         name: String
-        repos: [githubRepo]
+        repos: [GithubRepo]
     }
 
-    type githubRepo {
+    type GithubRepo {
         id: Int
         name: String
         githubUrl: String
@@ -69,7 +69,7 @@ module.exports = gql`
         getContributorById(id: Int!): Contributor
         getContributors: [Contributor]
         getGithubOrganizations(contributorId: Int): [ContributorOrganizations]
-        getGithubRepos(contributorId: Int):  [ContributorRepos]
+        getGithubRepos(organizationName: String!):  [GithubRepo]
     }
 
     type Mutation {

--- a/src/components/AddGithubProjectManually.js
+++ b/src/components/AddGithubProjectManually.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import {
     Box,
     Grid,
@@ -9,9 +9,6 @@ import {
 const AddGithubProjectManually = (props) => {
 
     const {
-        linkedRepo,
-        projectGithub,
-        setProjectGithub,
         setProjectGithubManual
     } = props
 
@@ -32,7 +29,6 @@ const AddGithubProjectManually = (props) => {
                         variant='outlined'
                         fullWidth
                         required
-                        disabled={linkedRepo}
                         onChange={(event) => setProjectGithubManual(event.target.value)}
                     />
                 </Box>

--- a/src/components/AddProjectForm.js
+++ b/src/components/AddProjectForm.js
@@ -71,11 +71,11 @@ const AddProjectForm = (props) => {
     const [createProjectError, setCreateProjectError] = useState(null)
     const [disableAdd, setDisableAdd] = useState(true)
     const [displayError, setDisplayError] = useState(false)
-    const [linkedRepo, setLinkedRepo] = useState(false)
+    const [linkedRepo, setLinkedRepo] = useState(false) //TODO: Check if it can be deleted
     const [projectBudget, setProjectBudget] = useState(0)
     const [projectDate, setProjectDate] = useState(null)
     const [projectEndDate, setProjectEndDate] = useState(null)
-    const [projectGithub, setProjectGithub] = useState(null)
+    const [projectGithub, setProjectGithub] = useState(null) //TODO: Change to projectGithubURL
     const [projectGithubManual, setProjectGithubManual] = useState(null)
     const [projectName, setProjectName] = useState('')
     const [projectToggl, setProjectToggl] = useState(null)

--- a/src/components/AddProjectForm.js
+++ b/src/components/AddProjectForm.js
@@ -71,17 +71,16 @@ const AddProjectForm = (props) => {
     const [createProjectError, setCreateProjectError] = useState(null)
     const [disableAdd, setDisableAdd] = useState(true)
     const [displayError, setDisplayError] = useState(false)
-    const [linkedRepo, setLinkedRepo] = useState(false) //TODO: Check if it can be deleted
     const [projectBudget, setProjectBudget] = useState(0)
     const [projectDate, setProjectDate] = useState(null)
     const [projectEndDate, setProjectEndDate] = useState(null)
-    const [projectGithub, setProjectGithub] = useState(null) //TODO: Change to projectGithubURL
+    const [projectGithubURL, setProjectGithubURL] = useState(null)
     const [projectGithubManual, setProjectGithubManual] = useState(null)
     const [projectName, setProjectName] = useState('')
     const [projectToggl, setProjectToggl] = useState(null)
 
     useEffect(() => {
-        if (!projectName || !projectGithub || !projectDate || !projectBudget || budgetTimeframe == null) {
+        if (!projectName || !projectGithubURL || !projectDate || !projectBudget || budgetTimeframe == null) {
             setDisableAdd(true)
         } else {
             setDisableAdd(false)
@@ -90,18 +89,18 @@ const AddProjectForm = (props) => {
 
     useEffect(() => {
         //if there's not a linked github repo from the selector use the one inserted manually if exists
-        if (projectGithubManual && !projectGithub) {
-            setProjectGithub(projectGithubManual)
+        if (projectGithubManual && !projectGithubURL) {
+            setProjectGithubURL(projectGithubManual)
         }
-    }, [projectGithub, projectGithubManual])
+    }, [projectGithubURL, projectGithubManual])
 
     useEffect(() => {
-        const githubLinkInformation = split(projectGithub, '/')
+        const githubLinkInformation = split(projectGithubURL, '/')
         setProjectName(githubLinkInformation[githubLinkInformation.length - 1])
-    }, [projectGithub])
+    }, [projectGithubURL])
 
     const createProject = async () => {
-        if (!verifyGithubURL(projectGithub)) {
+        if (!verifyGithubURL(projectGithubURL)) {
             setCreateProjectError('The Github URL is invalid')
             setDisplayError(true)
             return
@@ -116,7 +115,7 @@ const AddProjectForm = (props) => {
         const newProjectVariables = {
             client_id: Number(clientId),
             name: projectName,
-            github_url: projectGithub,
+            github_url: projectGithubURL,
             date: projectDate,
             end_date: projectEndDate,
             expected_budget: Number(projectBudget),
@@ -173,18 +172,13 @@ const AddProjectForm = (props) => {
             <Grid item xs={12}>
                 <Box item mb={3}>
                     <AddProjectFromGithub
-                        clientId={clientId}
-                        setLinkedRepo={setLinkedRepo}
-                        setProjectGithub={setProjectGithub}
+                        setProjectGithubURL={setProjectGithubURL}
                     />
                 </Box>
             </Grid>
             <Grid item xs={12}>
                 <Box item mb={3}>
                     <AddGithubProjectManually
-                        linkedRepo={linkedRepo}
-                        projectGithub={projectGithub}
-                        setProjectGithub={setProjectGithub}
                         setProjectGithubManual={setProjectGithubManual}
                     />
                 </Box>

--- a/src/components/AddProjectFromGithub.js
+++ b/src/components/AddProjectFromGithub.js
@@ -41,6 +41,14 @@ const AddProjectFromGithub = (props) => {
 
     useEffect(() => {
         setSelectedGithubRepo(0)
+
+        if (dataOrganizations) {
+            getRepos({
+                variables: {
+                    organizationName: organizations[selectedGithubOrganization].name
+                }
+            })
+        }
     }, [selectedGithubOrganization])
 
     const handleGithubOrganizationChange = ({ organizations, value }) => {
@@ -93,10 +101,12 @@ const AddProjectFromGithub = (props) => {
     if (errorOrganizationRepos) return `An error ocurred ${errorOrganizationRepos}`
 
     const { getGithubOrganizations } = dataOrganizations
-    //const { getGithubRepos } = dataOrganizationRepos
+    const { getGithubRepos } = dataOrganizationRepos && dataOrganizationRepos.getGithubRepos
+        ? dataOrganizationRepos
+        : []
 
     const organizations = [...getGithubOrganizations]
-    //const repos = [...getGithubRepos]
+    const repos = [...getGithubRepos]
 
     return (
         <Grid
@@ -121,11 +131,6 @@ const AddProjectFromGithub = (props) => {
                     <Select
                         fullWidth
                         value={selectedGithubOrganization}
-                        onLoad={() => getRepos({
-                            variables: {
-                                organizationName: organizations[selectedGithubOrganization].name
-                            }
-                        })}
                         onChange={() => getRepos({
                             variables: { organizationName: organizations[selectedGithubOrganization].name }
                         })}
@@ -148,7 +153,7 @@ const AddProjectFromGithub = (props) => {
                         })}
                     >
                         {renderGithubRepos({
-                            repos: organizations
+                            repos: repos
                         })}
                     </Select>
                 </FormControl>

--- a/src/components/AddProjectFromGithub.js
+++ b/src/components/AddProjectFromGithub.js
@@ -13,7 +13,8 @@ import {
 
 import LoadingProgress from './LoadingProgress'
 import {
-    GET_CONTRIBUTOR_ORGANIZATIONS_REPOS_FROM_GITHUB
+    GET_CONTRIBUTOR_ORGANIZATIONS_FROM_GITHUB,
+    GET_CONTRIBUTOR_REPOS_FROM_GITHUB
 } from '../operations/queries/ContributorQueries'
 
 const AddProjectFromGithub = (props) => {
@@ -24,10 +25,16 @@ const AddProjectFromGithub = (props) => {
     } = props
 
     const {
-        error: errorOrganizationProjects,
-        data: dataOrganizationProjects,
-        loading: loadingOrganizationProjects
-    } = useQuery(GET_CONTRIBUTOR_ORGANIZATIONS_REPOS_FROM_GITHUB)
+        error: errorOrganizations,
+        data: dataOrganizations,
+        loading: loadingOrganizations
+    } = useQuery(GET_CONTRIBUTOR_ORGANIZATIONS_FROM_GITHUB)
+
+    const {
+        error: errorOrganizationRepos,
+        data: dataOrganizationRepos,
+        loading: loadingOrganizationRepos
+    } = useQuery(GET_CONTRIBUTOR_REPOS_FROM_GITHUB)
 
     const [selectedGithubOrganization, setSelectedGithubOrganization] = useState(0)
     const [selectedGithubRepo, setSelectedGithubRepo] = useState(0)
@@ -79,12 +86,17 @@ const AddProjectFromGithub = (props) => {
         })
     }
 
-    if (loadingOrganizationProjects) return <LoadingProgress/>
-    if (errorOrganizationProjects) return `An error ocurred ${errorOrganizationProjects}`
+    if (loadingOrganizations) return <LoadingProgress/>
+    if (errorOrganizations) return `An error ocurred ${errorOrganizations}`
 
-    const { getGithubOrganizations } = dataOrganizationProjects
+    if (loadingOrganizationRepos) return <LoadingProgress/>
+    if (errorOrganizationRepos) return `An error ocurred ${errorOrganizationRepos}`
 
-    const organizations = [{ repos: [] }, ...getGithubOrganizations]
+    const { getGithubOrganizations } = dataOrganizations
+    const { getGithubRepos } = dataOrganizationRepos
+
+    const organizations = [...getGithubOrganizations]
+    const repos = [...getGithubRepos]
 
     return (
         <Grid
@@ -110,7 +122,7 @@ const AddProjectFromGithub = (props) => {
                         fullWidth
                         value={selectedGithubOrganization}
                         onChange={(event) => handleGithubOrganizationChange({
-                            organizations: organizations,
+                            organizations: repos,
                             value: event.target.value
                         })}
                     >
@@ -127,12 +139,12 @@ const AddProjectFromGithub = (props) => {
                         fullWidth
                         value={selectedGithubRepo}
                         onChange={(event) => handleGithubRepoChange({
-                            organizations: organizations,
+                            organizations: repos,
                             value: event.target.value
                         })}
                     >
                         {renderGithubRepos({
-                            repos: organizations[selectedGithubOrganization].repos
+                            repos: repos[selectedGithubOrganization].repos
                         })}
                     </Select>
                 </FormControl>

--- a/src/components/AddProjectFromGithub.js
+++ b/src/components/AddProjectFromGithub.js
@@ -58,7 +58,7 @@ const AddProjectFromGithub = (props) => {
     const [selectedGithubRepo, setSelectedGithubRepo] = useState(null)
 
     useEffect(() => {
-        if (dataOrganizations) {
+        if (dataOrganizations && selectedGithubOrganization) {
             getRepos({
                 variables: {
                     organizationName: selectedGithubOrganization.name
@@ -118,7 +118,7 @@ const AddProjectFromGithub = (props) => {
     if (errorOrganizationRepos) return `An error ocurred ${errorOrganizationRepos}`
 
     const githubOrganizations = dataOrganizations.getGithubOrganizations
-    const githubRepos = dataOrganizationRepos && dataOrganizationRepos.length
+    const githubRepos = dataOrganizationRepos
         ? dataOrganizationRepos.getGithubRepos
         : []
 

--- a/src/components/AddProjectFromGithub.js
+++ b/src/components/AddProjectFromGithub.js
@@ -19,9 +19,7 @@ import {
 
 const AddProjectFromGithub = (props) => {
     const {
-        clientId,
-        setLinkedRepo,
-        setProjectGithub
+        setProjectGithubURL
     } = props
 
     const {
@@ -69,20 +67,9 @@ const AddProjectFromGithub = (props) => {
 
     useEffect(() => {
         if (selectedGithubRepo) {
-            setProjectGithub(selectedGithubRepo.githubUrl)
+            setProjectGithubURL(selectedGithubRepo.githubUrl)
         }
     }, [selectedGithubRepo])
-
-    const handleGithubOrganizationChange = ({ organizations, value }) => {
-        setSelectedGithubOrganization(value)
-        if (organizations[value].repos[0]) {
-            setProjectGithub(organizations[value].repos[0].githubUrl)
-            setLinkedRepo(true)
-        } else {
-            setProjectGithub(null)
-            setLinkedRepo(false)
-        }
-    }
 
     const renderGithubOrganizations = ({ organizations }) => {
         return organizations.map((o, i) => {

--- a/src/operations/queries/ContributorQueries.js
+++ b/src/operations/queries/ContributorQueries.js
@@ -120,9 +120,19 @@ export const GET_CONTRIBUTOR_PROJECTS = gql`
     }
 `
 
-export const GET_CONTRIBUTOR_ORGANIZATIONS_REPOS_FROM_GITHUB = gql`
-    query GithubOrganizationRepos($id: Int) {
+export const GET_CONTRIBUTOR_ORGANIZATIONS_FROM_GITHUB = gql`
+    query GithubOrganizations($id: Int) {
         getGithubOrganizations(contributorId: $id) {
+            id
+            avatar
+            name
+        }
+    }
+`
+
+export const GET_CONTRIBUTOR_REPOS_FROM_GITHUB = gql`
+    query GithubOrganizationRepos($id: Int) {
+        getGithubRepos(contributorId: $id) {
             id
             avatar
             name

--- a/src/operations/queries/ContributorQueries.js
+++ b/src/operations/queries/ContributorQueries.js
@@ -131,16 +131,11 @@ export const GET_CONTRIBUTOR_ORGANIZATIONS_FROM_GITHUB = gql`
 `
 
 export const GET_CONTRIBUTOR_REPOS_FROM_GITHUB = gql`
-    query GithubOrganizationRepos($id: Int) {
-        getGithubRepos(contributorId: $id) {
+    query GithubOrganizationRepos($organizationName: String!) {
+        getGithubRepos(organizationName: $organizationName) {
             id
-            avatar
             name
-            repos {
-                id
-                name
-                githubUrl
-            }
+            githubUrl
         }
     }
 `


### PR DESCRIPTION
**Issue #424**
**Description**

We are separating the queries on the Add project from github view, so the selection of the organization has its own querie separated from the repo selection. Currently when you select an organization it makes the request and gets all the repos from that organization.

Implementation proof
https://www.loom.com/share/4d4774214b1248159022c286dd785fae

Thanks to @sofiarm21 for the help!