### PR TITLE
Allocation form not saving date properly

### DIFF
--- a/src/components/AllocationOverview.js
+++ b/src/components/AllocationOverview.js
@@ -132,9 +132,9 @@ const AllocationOverview = (props) => {
                     id: contributorAllocation.contributor.id
                 }
             })
-            setUpdatedAllocationEndDate(moment.utc(allocation.end_date, 'x')['_d'])
+            setUpdatedAllocationEndDate(moment.utc(allocation.end_date, 'x').toDate())
             setUpdatedAllocationPayment(contributorAllocation.payment)
-            setUpdatedAllocationStartDate(moment.utc(allocation.start_date, 'x')['_d'])
+            setUpdatedAllocationStartDate(moment.utc(allocation.start_date, 'x').toDate())
         }
     }, [contributorAllocation])
 
@@ -189,8 +189,8 @@ const AllocationOverview = (props) => {
                 variables: {
                     id: allocation.id,
                     amount: Number(rate.total_amount),
-                    start_date: moment(startDate).format('YYYY-MM-DD'),
-                    end_date: moment(endDate).format('YYYY-MM-DD'),
+                    start_date: moment.utc(startDate).format('YYYY-MM-DD'),
+                    end_date: moment.utc(endDate).format('YYYY-MM-DD'),
                     date_paid: null,
                     rate_id: Number(selectedRate.id),
                     payment_id: payment ? payment.id : null

--- a/src/components/AllocationTile.js
+++ b/src/components/AllocationTile.js
@@ -78,7 +78,7 @@ const AllocationTile = (props) => {
                             {`Start:`}
                             <br/>
                             <strong>
-                                {`${moment.utc(allocation.start_date, 'x').format('MM/DD/YYYY')}`}
+                                {`${moment(allocation.start_date, 'x').format('MM/DD/YYYY')}`}
                             </strong>
                         </Typography>
                     </Box>

--- a/src/components/ContributorTile.js
+++ b/src/components/ContributorTile.js
@@ -148,7 +148,7 @@ const ContributorTile = (props) => {
                                         {`Start date:`}
                                     </strong>
                                     <br/>
-                                    {`${moment.utc(a.start_date, 'x').format('MM/DD/YYYY')}`}
+                                    {`${moment(a.start_date, 'x').format('MM/DD/YYYY')}`}
                                 </Typography>
                             </Grid>
                             <Grid item xs={4}>
@@ -160,7 +160,7 @@ const ContributorTile = (props) => {
                                         {`End date:`}
                                     </strong>
                                     <br/>
-                                    {`${moment.utc(a.end_date, 'x').format('MM/DD/YYYY')}`}
+                                    {`${moment(a.end_date, 'x').format('MM/DD/YYYY')}`}
                                 </Typography>
                             </Grid>
                             <Grid item xs={4}>

--- a/src/components/EditAllocationRate.js
+++ b/src/components/EditAllocationRate.js
@@ -84,11 +84,11 @@ const EditAllocationRate = (props) => {
                             >
                                 <RangeDatePickerInput
                                     startDate={startDate
-                                        ? moment.utc(startDate).format('MM/DD/YYYY')
+                                        ? startDate
                                         : 'Start date'
                                     }
                                     endDate={endDate
-                                        ? moment.utc(endDate).format('MM/DD/YYYY')
+                                        ? endDate
                                         : 'End date'
                                     }
                                 />

--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -145,7 +145,7 @@ const PaymentTile = (props) => {
                         </Grid>
                         <Grid item xs={5} align='right'>
                             <Typography color='secondary' variant='caption'>
-                                {`Ends ${moment.utc(end_date, 'x').format('MM/DD/YYYY')} `}
+                                {`Ends ${moment(end_date, 'x').format('MM/DD/YYYY')} `}
                             </Typography>
                         </Grid>
                     </Grid>


### PR DESCRIPTION
**Issue #488**
**Description**
The dates from allocations were not being saved properly. This was happening because of the use of `moment.utc()` everywhere in the code, this was making the calendar display different dates than the ones that were displayed in the `ContributorTile` and `PaymentTile`.

**Proof**
![image](https://user-images.githubusercontent.com/86666889/129042977-464a133b-52c7-47ea-b445-77b1baaeeda8.png)
![image](https://user-images.githubusercontent.com/86666889/129043040-6519e87a-23ab-4f91-b877-2baa80aacf34.png)
![image](https://user-images.githubusercontent.com/86666889/129043068-66d7c3a8-d903-48ec-9bbc-4e2b5be71428.png)