### PR TITLE
Payments with no date paid sorting incorrectly

### DIFF
--- a/src/components/ClientPayments.js
+++ b/src/components/ClientPayments.js
@@ -18,7 +18,7 @@ const ClientPayments = (props) => {
     if (loading) return <LoadingProgress/>
     if (error) return `Error! ${error.message}`
 
-    const payments = orderBy(data.getClientPaymentsByClientId, ['date_paid'], ['desc'])
+    const payments = orderBy(data.getClientPaymentsByClientId, ['date_incurred'], ['desc'])
 
     return (
         payments.length != 0

--- a/src/components/ClientPayments.js
+++ b/src/components/ClientPayments.js
@@ -18,7 +18,7 @@ const ClientPayments = (props) => {
     if (loading) return <LoadingProgress/>
     if (error) return `Error! ${error.message}`
 
-    const payments = orderBy(data.getClientPaymentsByClientId, ['date_incurred'], ['desc'])
+    const payments = orderBy(data.getClientPaymentsByClientId, ['date_paid', 'date_incurred'], ['desc', 'desc'])
 
     return (
         payments.length != 0


### PR DESCRIPTION
**Issue #487**
**Description**
Payments were being sorted by date_paid, this was causing that payments without date_paid were not being sorted.
To fix this problem the sort was changed from date_paid to date_incurred in `ClientPayments.js`

**Proof**
![image](https://user-images.githubusercontent.com/86666889/129924188-74a13fd3-be52-46d1-8b20-009f0d405314.png)