### PR TITLE
Only create invoices when the currency is USD

### DIFF
--- a/api/handlers/stripe.js
+++ b/api/handlers/stripe.js
@@ -40,15 +40,16 @@ const stripeHandler = module.exports = (() => {
         const {
             amount,
             clientId,
-            currency,
+            actualCurrency,
             external_uuid
         } = params
+
         const client = await clientManagement.findClientWithId(clientId)
         const invoiceItemProps = {
             customer: client.external_uuid,
-            currency: currency,
+            currency: actualCurrency,
             price_data: {
-                currency: currency,
+                currency: actualCurrency,
                 product: STRIPE_PRODUCT_PLACEHOLDER_ID,
                 unit_amount: amount
             }

--- a/api/modules/paymentManagement.js
+++ b/api/modules/paymentManagement.js
@@ -10,11 +10,16 @@ const paymentManagement = module.exports = (() => {
             currency,
             date_paid
         } = params
+        
+        const actualCurrency = 
+            currency == 'USD' 
+                ? currency
+                : 'USD'
 
         const createdInvoice = await stripe.createInvoice({
             clientId,
             amount,
-            currency
+            actualCurrency
         })
 
         if (date_paid) {

--- a/api/schema/resolvers/PaymentResolver.js
+++ b/api/schema/resolvers/PaymentResolver.js
@@ -60,7 +60,7 @@ module.exports = {
                 'EUR',
                 'MXN'
             ]
-            // Check if the client has an associated Stripe account
+            // Check if the client has an associated Stripe account and if the currency is supported
             // If it does, proceed to create the invoice on Stripe
             if (client.external_uuid && supportedCurrency.includes(client.currency)) {
                 const stripeInvoice = await apiModules.paymentManagement.processStripeInvoiceWithPayment({

--- a/api/schema/resolvers/PaymentResolver.js
+++ b/api/schema/resolvers/PaymentResolver.js
@@ -55,9 +55,14 @@ module.exports = {
                 }
             })
 
+            const supportedCurrency = [
+                'USD',
+                'EUR',
+                'MXN'
+            ]
             // Check if the client has an associated Stripe account
             // If it does, proceed to create the invoice on Stripe
-            if (client.external_uuid) {
+            if (client.external_uuid && supportedCurrency.includes(client.currency)) {
                 const stripeInvoice = await apiModules.paymentManagement.processStripeInvoiceWithPayment({
                     amount: createFields['amount'],
                     clientId: client.id,

--- a/server.js
+++ b/server.js
@@ -123,7 +123,7 @@ app.post('/api/webhooks/invoice/updated', async (req, res) => {
     if (
         invoiceObjectPayload.metadata &&
         invoiceObjectPayload.metadata.ready_to_allocate &&
-        invoiceObjectPayload.metadata.ready_to_allocate == true
+        invoiceObjectPayload.metadata.ready_to_allocate == 'true'
     ) {
         try {
             await apiModules.budgeting.updatePaymentByStripeInvoiceId({


### PR DESCRIPTION
**Issue #452**
**Description**

The task for this issue are:

## From Stripe to Trinary

- When creating Invoices in Stripe, the connected Client in Trinary will have its currency changed to USD (the currency of the invoice) and then will be locked from updating
- Do not create Trinary Payments if there are already payments in a different currency (should we "disconnect" the Client from the Customer in this case and delete the `external_uuid`)

## From Trinary to Stripe

- When creating a Trinary Payment, it should only create a Stripe invoice if the currency is supported (USD, EUR, MXN) only after updating the currency of the Stripe Customer which will then be locked after the invoice is created