### PR TITLE
Add pagination to the repository selection

### DIFF
--- a/api/handlers/github.js
+++ b/api/handlers/github.js
@@ -61,14 +61,14 @@ const github = module.exports = (() => {
         const res = params.isOrganization
             ? await octokit.repos.listForOrg({ 
                 org: params.organizationName,
-                per_page: 100,
+                per_page: 5,
                 sort: 'updated',
                 direction: 'desc',
                 page: params.githubPageNumber
             })
             : await octokit.repos.listForUser({
                 username: params.organizationName,
-                per_page: 100,
+                per_page: 5,
                 sort: 'updated',
                 direction: 'desc',
                 page: params.githubPageNumber

--- a/api/handlers/github.js
+++ b/api/handlers/github.js
@@ -64,12 +64,14 @@ const github = module.exports = (() => {
                 per_page: 100,
                 sort: 'updated',
                 direction: 'desc',
+                page: params.githubPageNumber
             })
             : await octokit.repos.listForUser({
                 username: params.organizationName,
                 per_page: 100,
                 sort: 'updated',
                 direction: 'desc',
+                page: params.githubPageNumber
             })
         if (res.status == 200) {
             return res.data

--- a/api/handlers/github.js
+++ b/api/handlers/github.js
@@ -61,14 +61,14 @@ const github = module.exports = (() => {
         const res = params.isOrganization
             ? await octokit.repos.listForOrg({ 
                 org: params.organizationName,
-                per_page: 5,
+                per_page: 100,
                 sort: 'updated',
                 direction: 'desc',
                 page: params.githubPageNumber
             })
             : await octokit.repos.listForUser({
                 username: params.organizationName,
-                per_page: 5,
+                per_page: 100,
                 sort: 'updated',
                 direction: 'desc',
                 page: params.githubPageNumber

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -38,6 +38,7 @@ const automations = module.exports = (() => {
         const repos = await github.fetchRepos({
             auth_key: params.auth_key,
             organizationName: params.organizationName,
+            githubPageNumber: params.githubPageNumber,
             isOrganization
         })
         const organizationRepos = []

--- a/api/schema/resolvers/ContributorResolver.js
+++ b/api/schema/resolvers/ContributorResolver.js
@@ -98,7 +98,7 @@ module.exports = {
             })
             return contributorOrganizations
         },
-        getGithubRepos: async (root, { organizationName }, { cookies, models }) => {
+        getGithubRepos: async (root, { organizationName, githubPageNumber }, { cookies, models }) => {
             const contributor = (
                 await models.Contributor.findByPk(
                     cookies.userSession
@@ -108,7 +108,8 @@ module.exports = {
             )
             const contributorOrganizations = await apiModules.automations.getOrganizationRepos({
                 auth_key: contributor.github_access_token,
-                organizationName: organizationName
+                organizationName: organizationName,
+                githubPageNumber
             })
             return contributorOrganizations
         }

--- a/api/schema/types/ContributorType.js
+++ b/api/schema/types/ContributorType.js
@@ -69,7 +69,10 @@ module.exports = gql`
         getContributorById(id: Int!): Contributor
         getContributors: [Contributor]
         getGithubOrganizations(contributorId: Int): [ContributorOrganizations]
-        getGithubRepos(organizationName: String!):  [GithubRepo]
+        getGithubRepos(
+            organizationName: String!
+            githubPageNumber: Int!
+        ):  [GithubRepo]
     }
 
     type Mutation {

--- a/src/components/AddProjectFromGithub.js
+++ b/src/components/AddProjectFromGithub.js
@@ -136,8 +136,8 @@ const AddProjectFromGithub = (props) => {
 
     const renderMoreItem = ( itemValue ) => {
         return (
-            <MenuItem value={itemValue + 1}>
-                {`...more`}
+            <MenuItem value={itemValue + 1}  >
+                <Typography color='primary'>...more</Typography>
             </MenuItem>
         )
     }

--- a/src/components/AddProjectFromGithub.js
+++ b/src/components/AddProjectFromGithub.js
@@ -45,13 +45,15 @@ const AddProjectFromGithub = (props) => {
     }] = useLazyQuery(GET_CONTRIBUTOR_REPOS_FROM_GITHUB, {
         onCompleted: dataOrganizationRepos => {
             const {
-                getGithubRepos
+                getGithubRepos: { length }
             } = dataOrganizationRepos
-            if (getGithubRepos.length) {
+            if (length) {
                 setSelectedGithubRepo(dataOrganizationRepos.getGithubRepos[0])
             }
-            if (getGithubRepos.length > 99) {
+            if (length > 99) {
                 setMoreRepoState(true)
+            } else {
+                setMoreRepoState(false)
             }
         }
     })
@@ -73,6 +75,8 @@ const AddProjectFromGithub = (props) => {
     useEffect(() => {
         if (selectedGithubRepo) {
             setProjectGithubURL(selectedGithubRepo.githubUrl)
+        } else {
+            // TODO: create a query and pass the page number to github api
         }
     }, [selectedGithubRepo])
 
@@ -103,12 +107,10 @@ const AddProjectFromGithub = (props) => {
         })
     }
 
-    const renderMoreButton = ( itemValue ) => {
+    const renderMoreItem = ( itemValue ) => {
         return (
             <MenuItem value={itemValue + 1}>
-                <Link href='#' variant='body2'>
-                    ...more
-                </Link>
+                ...more
             </MenuItem>
         )
     }
@@ -168,7 +170,7 @@ const AddProjectFromGithub = (props) => {
                         {renderGithubRepos({
                             repos: githubRepos
                         })}
-                        { MoreRepoState ? renderMoreButton(githubRepos.length) : null }
+                        { MoreRepoState ? renderMoreItem(githubRepos.length) : null }
                     </Select>
                 </FormControl>
             </Grid>

--- a/src/components/AddProjectFromGithub.js
+++ b/src/components/AddProjectFromGithub.js
@@ -49,11 +49,15 @@ const AddProjectFromGithub = (props) => {
             if (getGithubRepos.length) {
                 setSelectedGithubRepo(dataOrganizationRepos.getGithubRepos[0])
             }
+            if (getGithubRepos.length > 99) {
+                setMoreRepoState(true)
+            }
         }
     })
 
     const [selectedGithubOrganization, setSelectedGithubOrganization] = useState(null)
     const [selectedGithubRepo, setSelectedGithubRepo] = useState(null)
+    const [MoreRepoState, setMoreRepoState] = useState(false)
 
     useEffect(() => {
         if (dataOrganizations && selectedGithubOrganization) {
@@ -93,6 +97,7 @@ const AddProjectFromGithub = (props) => {
             return (
                 <MenuItem value={i}>
                     {`${r.name ? r.name : 'Select'}`}
+                    { (repos.length - 1) == i ? ' more' : null }
                 </MenuItem>
             )
         })

--- a/src/components/AddProjectFromGithub.js
+++ b/src/components/AddProjectFromGithub.js
@@ -50,7 +50,7 @@ const AddProjectFromGithub = (props) => {
             if (length) {
                 setSelectedGithubRepo(dataOrganizationRepos.getGithubRepos[0])
             }
-            if (length > 99) {
+            if (length > 4) {
                 setMoreRepoState(true)
             } else {
                 setMoreRepoState(false)
@@ -68,7 +68,7 @@ const AddProjectFromGithub = (props) => {
             getRepos({
                 variables: {
                     organizationName: selectedGithubOrganization.name,
-                    githubPageNumber: actualGithubPage
+                    githubPageNumber: actualGithubPage - 1
                 }
             })
         }
@@ -76,9 +76,16 @@ const AddProjectFromGithub = (props) => {
 
     useEffect(() => {
         if (selectedGithubRepo) {
+            setActualGithubPage(1)
             setProjectGithubURL(selectedGithubRepo.githubUrl)
-        } else {
-            // TODO: create a query and pass the page number to github api
+        } else if (selectedGithubRepo == undefined && MoreRepoState) {
+            setActualGithubPage( actualGithubPage + 1)
+            getRepos({
+                variables: {
+                    organizationName: selectedGithubOrganization.name,
+                    githubPageNumber: actualGithubPage + 1
+                }
+            })
         }
     }, [selectedGithubRepo])
 
@@ -112,7 +119,7 @@ const AddProjectFromGithub = (props) => {
     const renderMoreItem = ( itemValue ) => {
         return (
             <MenuItem value={itemValue + 1}>
-                ...more
+                {`...more`}
             </MenuItem>
         )
     }

--- a/src/components/AddProjectFromGithub.js
+++ b/src/components/AddProjectFromGithub.js
@@ -61,12 +61,14 @@ const AddProjectFromGithub = (props) => {
     const [selectedGithubOrganization, setSelectedGithubOrganization] = useState(null)
     const [selectedGithubRepo, setSelectedGithubRepo] = useState(null)
     const [MoreRepoState, setMoreRepoState] = useState(false)
+    const [actualGithubPage, setActualGithubPage] = useState(1)
 
     useEffect(() => {
         if (dataOrganizations && selectedGithubOrganization) {
             getRepos({
                 variables: {
-                    organizationName: selectedGithubOrganization.name
+                    organizationName: selectedGithubOrganization.name,
+                    githubPageNumber: actualGithubPage
                 }
             })
         }

--- a/src/components/AddProjectFromGithub.js
+++ b/src/components/AddProjectFromGithub.js
@@ -57,7 +57,7 @@ const AddProjectFromGithub = (props) => {
                     }
                 })
             }
-            if (length >= 5) {
+            if (length >= 99) {
                 setHasMoreRepos(true)
             } else {
                 setHasMoreRepos(false)

--- a/src/components/AddProjectFromGithub.js
+++ b/src/components/AddProjectFromGithub.js
@@ -6,6 +6,7 @@ import {
     FormControl,
     Grid,
     InputLabel,
+    Link,
     MenuItem,
     Select,
     Typography
@@ -97,10 +98,19 @@ const AddProjectFromGithub = (props) => {
             return (
                 <MenuItem value={i}>
                     {`${r.name ? r.name : 'Select'}`}
-                    { (repos.length - 1) == i ? ' more' : null }
                 </MenuItem>
             )
         })
+    }
+
+    const renderMoreButton = ( itemValue ) => {
+        return (
+            <MenuItem value={itemValue + 1}>
+                <Link href='#' variant='body2'>
+                    ...more
+                </Link>
+            </MenuItem>
+        )
     }
 
     if (loadingOrganizations) return <LoadingProgress/>
@@ -158,6 +168,7 @@ const AddProjectFromGithub = (props) => {
                         {renderGithubRepos({
                             repos: githubRepos
                         })}
+                        { MoreRepoState ? renderMoreButton(githubRepos.length) : null }
                     </Select>
                 </FormControl>
             </Grid>

--- a/src/components/AddProjectFromGithub.js
+++ b/src/components/AddProjectFromGithub.js
@@ -51,16 +51,16 @@ const AddProjectFromGithub = (props) => {
                 setSelectedGithubRepo(dataOrganizationRepos.getGithubRepos[0])
             }
             if (length > 4) {
-                setMoreRepoState(true)
+                setHasMoreRepos(true)
             } else {
-                setMoreRepoState(false)
+                setHasMoreRepos(false)
             }
         }
     })
 
     const [selectedGithubOrganization, setSelectedGithubOrganization] = useState(null)
     const [selectedGithubRepo, setSelectedGithubRepo] = useState(null)
-    const [MoreRepoState, setMoreRepoState] = useState(false)
+    const [hasMoreRepos, setHasMoreRepos] = useState(false)
     const [actualGithubPage, setActualGithubPage] = useState(1)
 
     useEffect(() => {
@@ -78,7 +78,7 @@ const AddProjectFromGithub = (props) => {
         if (selectedGithubRepo) {
             setActualGithubPage(1)
             setProjectGithubURL(selectedGithubRepo.githubUrl)
-        } else if (selectedGithubRepo == undefined && MoreRepoState) {
+        } else if (selectedGithubRepo == undefined && hasMoreRepos) {
             setActualGithubPage( actualGithubPage + 1)
             getRepos({
                 variables: {
@@ -179,7 +179,7 @@ const AddProjectFromGithub = (props) => {
                         {renderGithubRepos({
                             repos: githubRepos
                         })}
-                        { MoreRepoState ? renderMoreItem(githubRepos.length) : null }
+                        { hasMoreRepos ? renderMoreItem(githubRepos.length) : null }
                     </Select>
                 </FormControl>
             </Grid>

--- a/src/operations/queries/ContributorQueries.js
+++ b/src/operations/queries/ContributorQueries.js
@@ -131,8 +131,8 @@ export const GET_CONTRIBUTOR_ORGANIZATIONS_FROM_GITHUB = gql`
 `
 
 export const GET_CONTRIBUTOR_REPOS_FROM_GITHUB = gql`
-    query GithubOrganizationRepos($organizationName: String!) {
-        getGithubRepos(organizationName: $organizationName) {
+    query GithubOrganizationRepos($organizationName: String!, $githubPageNumber: Int!) {
+        getGithubRepos(organizationName: $organizationName, githubPageNumber: $githubPageNumber) {
             id
             name
             githubUrl


### PR DESCRIPTION
**Issue #429 **
**Description**

We want to add a pagination to repository selection in the AddProjectFromGithub when a org has > 100 repos. Using the page property of the Github API we can have a pagination if the org/user has more than 100 repos.

**Implementation Proof**
https://www.loom.com/share/5fe4f9b23964407da88c44e05099734f