### PR TITLE
Sort and separated allocations on Contributor Detail

### DIFF
--- a/src/components/ContributorAllocations.js
+++ b/src/components/ContributorAllocations.js
@@ -6,6 +6,7 @@ import {
     Grid,
     Typography
 } from '@material-ui/core'
+import SortIcon from '@material-ui/icons/Sort'
 import { isEmpty } from 'lodash'
 
 import AllocationAddForm from './AllocationAddForm'
@@ -91,6 +92,14 @@ const ContributorAllocations = (props) => {
                         </Box>
                     </Button>
                 </Grid>
+                <Grid item xs='auto'>
+                    <Button>
+                        <SortIcon/>
+                    </Button>
+                </Grid>
+                <Grid item xs={12}>
+                    {`Allocated`}
+                </Grid>
                 <Grid item xs={12}>
                     <Grid container spacing={5}>
                         {!isEmpty(contributorAllocations.allocations)
@@ -103,6 +112,9 @@ const ContributorAllocations = (props) => {
                             )
                         }
                     </Grid>
+                </Grid>
+                <Grid item xs={12}>
+                    {`Proposed`}
                 </Grid>
             </Grid>
             <AllocationAddForm

--- a/src/pages/ContributorDetailPage.js
+++ b/src/pages/ContributorDetailPage.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import {
     Box,
-    Grid,
-    Typography
+    Grid
 } from '@material-ui/core'
 
 import ContributorAllocations from '../components/ContributorAllocations'


### PR DESCRIPTION
**Issue #507**

**Description**
The user should have an option to sort the allocations and he should be able to see which allocations have a payment and which ones don't.