### PR TITLE
Improve Toggl functionality

### DIFF
--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -29,12 +29,16 @@ const automations = module.exports = (() => {
 
     const getTogglPropertiesFromURL = async (params) => {
         // Url example https://track.toggl.com/3070292/projects/156669532
-        URL = params.toggl_url
+        URL = params
         const splitedUrl = URL.split(/\//)
-        const workspaceId = splitedUrl[2]
-        const projectId = splitedUrl[4]
+        try {
+            const workspaceId = splitedUrl[3]
+            const togglId = splitedUrl[5]
 
-        return { workspaceId, projectId }
+            return { workspaceId, togglId }
+        } catch (err) {
+            console.log('an error ocurred while spliting the toggl url: ', err)
+        }
     }
 
     const getUserOrganizations = async (params) => {

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -3,6 +3,40 @@ const db = require('../models')
 
 const automations = module.exports = (() => {
 
+    const getOrganizationRepos = async (params) => {
+        const organizations = await getUserOrganizations({
+            auth_key: params.auth_key
+        })
+        const isOrganization = organizations[0].name != params.organizationName
+
+        const repos = await github.fetchRepos({
+            auth_key: params.auth_key,
+            organizationName: params.organizationName,
+            isOrganization
+        })
+        const organizationRepos = []
+        repos.map(r => {
+            if (r.owner.login == params.organizationName) {
+                organizationRepos.push({
+                    id: r.id,
+                    name: r.name,
+                    githubUrl: r.html_url,
+                })
+            }
+        })
+        return organizationRepos
+    }
+
+    const getTogglPropertiesFromURL = async (params) => {
+        // Url example https://track.toggl.com/3070292/projects/156669532
+        URL = params.toggl_url
+        const splitedUrl = URL.split(/\//)
+        const workspaceId = splitedUrl[2]
+        const projectId = splitedUrl[4]
+
+        return { workspaceId, projectId }
+    }
+
     const getUserOrganizations = async (params) => {
         //user organizations are the organizations that the contributor is added as a internal collaborator
         //we also add the self github contributor user for implementation details
@@ -29,33 +63,10 @@ const automations = module.exports = (() => {
         return userOrganizations
     }
 
-    const getOrganizationRepos = async (params) => {
-        const organizations = await getUserOrganizations({
-            auth_key: params.auth_key
-        })
-        const isOrganization = organizations[0].name != params.organizationName
-        
-        const repos = await github.fetchRepos({
-            auth_key: params.auth_key,
-            organizationName: params.organizationName,
-            isOrganization
-        })
-        const organizationRepos = []
-        repos.map(r => {
-            if (r.owner.login == params.organizationName) {
-                organizationRepos.push({
-                    id: r.id,
-                    name: r.name,
-                    githubUrl: r.html_url,
-                })
-            }
-        })
-        return organizationRepos
-    }
-
     return {
-        getUserOrganizations,
         getOrganizationRepos,
+        getTogglPropertiesFromURL,
+        getUserOrganizations,
     }
 
 })()

--- a/api/modules/dataSyncs.js
+++ b/api/modules/dataSyncs.js
@@ -188,7 +188,7 @@ const dataSyncs = module.exports = (() => {
         try {
             const timeEntries = await toggl.fetchWorkspaceTimeEntries({
                 pId: params.toggl_project_id,
-                wId: TOGGL.WORKSPACE_ID,
+                wId: params.workspaceId,
                 since: params.since,
                 until: params.until
             })

--- a/api/schema/resolvers/ProjectResolver.js
+++ b/api/schema/resolvers/ProjectResolver.js
@@ -318,10 +318,10 @@ module.exports = {
                         [Op.between]: [
                             args.fromDate
                                 ? args.fromDate
-                                : moment.utc(1),
+                                : moment.utc(1).format('YYYY-MM-DD'),
                             args.toDate
                                 ? args.toDate
-                                : moment.utc()
+                                : moment.utc().format('YYYY-MM-DD')
                         ]
                     },
                     contributor_id: args.contributor_id
@@ -346,10 +346,10 @@ module.exports = {
                             [Op.between]: [
                                 args.fromDate
                                     ? args.fromDate
-                                    : moment.utc(1),
+                                    : moment.utc(1).format('YYYY-MM-DD'),
                                 args.toDate
                                     ? args.toDate
-                                    : moment.utc()
+                                    : moment.utc().format('YYYY-MM-DD')
                             ]
                         },
                     },
@@ -371,10 +371,10 @@ module.exports = {
                         [Op.between]: [
                             args.fromDate
                                 ? args.fromDate
-                                : moment.utc(1),
+                                : moment.utc(1).format('YYYY-MM-DD'),
                             args.toDate
                                 ? args.toDate
-                                : moment.utc()
+                                : moment.utc().format('YYYY-MM-DD')
                         ]
                     }
                 }
@@ -391,10 +391,11 @@ module.exports = {
                     [Op.between]:
                         [args.fromDate
                             ? args.fromDate
-                            : moment.utc(1),
+                            : moment.utc(1).format('YYYY-MM-DD'),
                         args.toDate
                             ? args.toDate
-                            : moment.utc()]
+                            : moment.utc().format('YYYY-MM-DD')
+                        ]
                 }
             }
             if (args.contributor_id) {

--- a/api/schema/resolvers/ProjectResolver.js
+++ b/api/schema/resolvers/ProjectResolver.js
@@ -609,6 +609,8 @@ module.exports = {
         },
         syncTogglProject: async (root, args, { models }) => {
             let project = await models.Project.findByPk(args.project_id)
+            const toggl_url = project.toggl_url
+            const togglPropertiesFromUrl = await apiModules.automations.getTogglPropertiesFromURL(toggl_url)
             if (!TOGGL.API_KEY) {
                 return new ApolloError('You need to setup a Toggl API KEY on the .env file', 2001)
             }
@@ -639,6 +641,7 @@ module.exports = {
             })
             const dataSync = await apiModules.dataSyncs.syncTogglProject({
                 toggl_project_id: project.toggl_id,
+                workspaceId: togglPropertiesFromUrl.workspaceId,
                 project_id: project.id,
                 since: lastEntrySynced
                     ? lastEntrySynced.created_at

--- a/api/schema/resolvers/ProjectResolver.js
+++ b/api/schema/resolvers/ProjectResolver.js
@@ -631,8 +631,9 @@ module.exports = {
                 //get updated project
                 project = await models.Project.findByPk(args.project_id)
             }
-            //search for the date of the last sync to fetch since taht date
+            //search for the date of the last sync to fetch since that date
             const lastEntrySynced = await models.TimeEntry.findOne({
+                where: { project_id: args.project_id },
                 order: [['created_at', 'DESC']]
             })
             const dataSync = await apiModules.dataSyncs.syncTogglProject({


### PR DESCRIPTION
**Issue #414**
**Description**

Improve the Toggl sync functionality for syncing the time entries per collaborator, toggl ID and workspace ID.

**Taks**
- Timestamp that gets added to the database was not properly formatted

- Add ability to extract `toggl_id` from the `toggl_url`
- 1. You can make sure the `toggl_id` gets updated when the Project is updated with the Toggl URL form the URL
- 2. Add an extra logic check in `syncTogglProject` that checks for a Toggl URL before failing

- Simplify the parameter logic to take a `toggl_url` which should have the toggl_id contained in it

**Currently testing**