### PR TITLE
Refactor GitHub account repo to use an AccountId instead of name

### DIFF
--- a/api/handlers/github.js
+++ b/api/handlers/github.js
@@ -60,14 +60,14 @@ const github = module.exports = (() => {
         })
         const res = params.isOrganization
             ? await octokit.repos.listForOrg({ 
-                org: params.organizationName,
+                org: params.accountName,
                 per_page: 100,
                 sort: 'updated',
                 direction: 'desc',
                 page: params.githubPageNumber
             })
             : await octokit.repos.listForUser({
-                username: params.organizationName,
+                username: params.accountName,
                 per_page: 100,
                 sort: 'updated',
                 direction: 'desc',

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -65,7 +65,7 @@ const automations = module.exports = (() => {
         })
         const organizationRepos = []
         repos.map(r => {
-            if (r.owner.login == accountName) {
+            if (r.owner.login == githubAccount.handle) {
                 organizationRepos.push({
                     id: r.id,
                     name: r.name,

--- a/api/modules/automations.js
+++ b/api/modules/automations.js
@@ -37,32 +37,31 @@ const automations = module.exports = (() => {
             }
         })
 
-        let organizations
-        let accountName
-        let isOrganization = false
+        const organizations = []
+        const githubAccount = {}
         if (contributor) {
-            const contributorSplit = contributor.github_handle.split(/\//)
-            accountName = contributorSplit[3]
+            githubAccount.handle = contributor.github_handle.split(/\//)[3]
         } else {
-            organizations = await getUserOrganizations({
-                auth_key: params.auth_key
-            })
+            organizations.push(
+                ...await getUserOrganizations({
+                    auth_key: params.auth_key
+                })
+            )
         }
 
-        if (organizations) {
-            isOrganization = true
-            organizations.map((org, i) => {
+        if (organizations.length) {
+            organizations.map((org) => {
                 if (org.id == params.accountId) {
-                    accountName = org.name
+                    githubAccount.handle = org.name
                 }
             })
         }
-        console.log(accountName, isOrganization)
         const repos = await github.fetchRepos({
             auth_key: params.auth_key,
-            accountName,
+            organizationName: params.organizationName,
+            accountName: githubAccount.handle,
             githubPageNumber: params.githubPageNumber,
-            isOrganization
+            isOrganization: organizations.length
         })
         const organizationRepos = []
         repos.map(r => {

--- a/api/schema/resolvers/ContributorResolver.js
+++ b/api/schema/resolvers/ContributorResolver.js
@@ -98,7 +98,7 @@ module.exports = {
             })
             return contributorOrganizations
         },
-        getGithubRepos: async (root, { organizationName, githubPageNumber }, { cookies, models }) => {
+        getGithubRepos: async (root, { githubPageNumber, accountId }, { cookies, models }) => {
             const contributor = (
                 await models.Contributor.findByPk(
                     cookies.userSession
@@ -108,7 +108,7 @@ module.exports = {
             )
             const contributorOrganizations = await apiModules.automations.getOrganizationRepos({
                 auth_key: contributor.github_access_token,
-                organizationName: organizationName,
+                accountId,
                 githubPageNumber
             })
             return contributorOrganizations

--- a/api/schema/types/ContributorType.js
+++ b/api/schema/types/ContributorType.js
@@ -70,8 +70,8 @@ module.exports = gql`
         getContributors: [Contributor]
         getGithubOrganizations(contributorId: Int): [ContributorOrganizations]
         getGithubRepos(
-            organizationName: String!
             githubPageNumber: Int!
+            accountId: Int!
         ):  [GithubRepo]
     }
 

--- a/src/components/AddProjectFromGithub.js
+++ b/src/components/AddProjectFromGithub.js
@@ -77,7 +77,7 @@ const AddProjectFromGithub = (props) => {
             setRepoOptions([])
             getRepos({
                 variables: {
-                    organizationName: selectedGithubOrganization.name,
+                    accountId: selectedGithubOrganization.id,
                     githubPageNumber: actualGithubPage
                 }
             })
@@ -136,7 +136,7 @@ const AddProjectFromGithub = (props) => {
 
     const renderMoreItem = ( itemValue ) => {
         return (
-            <MenuItem value={itemValue + 1}  >
+            <MenuItem value={itemValue + 1}>
                 <Typography color='primary'>...more</Typography>
             </MenuItem>
         )

--- a/src/operations/queries/ContributorQueries.js
+++ b/src/operations/queries/ContributorQueries.js
@@ -131,8 +131,12 @@ export const GET_CONTRIBUTOR_ORGANIZATIONS_FROM_GITHUB = gql`
 `
 
 export const GET_CONTRIBUTOR_REPOS_FROM_GITHUB = gql`
-    query GithubOrganizationRepos($organizationName: String!, $githubPageNumber: Int!) {
-        getGithubRepos(organizationName: $organizationName, githubPageNumber: $githubPageNumber) {
+    query GithubOrganizationRepos($githubPageNumber: Int!, $accountId: Int!) {
+        getGithubRepos(
+            githubPageNumber: $githubPageNumber, 
+            accountId: $accountId 
+        ) 
+        {
             id
             name
             githubUrl


### PR DESCRIPTION
**Issue #495**
**Description**

We wanted to use an Id instead of an username or organization name for the getGithubRepos query, so we changed the query so it can accept an accountId and then it uses a logic to check if its an user or an organization.

- [x] Changing the `getGithubRepos` query to accept an ID
- [x] Refactor functions called in the resolvers/modules/handlers and[ introduce `accountType` into the user vs organization logic](https://github.com/setlife-network/trinary/pull/483#discussion_r687084252)
- [x] Pass ID instead of name on the frontend

**impletentation proof**
https://www.loom.com/share/0d9f048aa01a41deaedd6b43f4005a42