### PR TITLE
Modify DataType of toggl_id on TimeEntries

### DIFF
--- a/api/migrations/20210223183216-addCurrencyToRates.js
+++ b/api/migrations/20210223183216-addCurrencyToRates.js
@@ -1,0 +1,19 @@
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        return queryInterface.sequelize.transaction(t => {
+            return Promise.all([
+                queryInterface.addColumn('Rates', 'currency', {
+                    type: Sequelize.DataTypes.STRING
+                }, { transaction: t })
+            ])
+        })
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        return queryInterface.sequelize.transaction(t => {
+            return Promise.all([
+                queryInterface.removeColumn('Rates', 'currency', { transaction: t })
+            ])
+        })
+    }
+};

--- a/api/migrations/20210930234711-modifyTogglIdDataTypeOnTimeEntries.js
+++ b/api/migrations/20210930234711-modifyTogglIdDataTypeOnTimeEntries.js
@@ -2,8 +2,8 @@ module.exports = {
     up: async (queryInterface, Sequelize) => {
         return queryInterface.sequelize.transaction(t => {
             return Promise.all([
-                queryInterface.addColumn('Rates', 'currency', {
-                    type: Sequelize.DataTypes.STRING
+                queryInterface.changeColumn('TimeEntries', 'toggl_id', {
+                    type: Sequelize.DataTypes.BIGINT
                 }, { transaction: t })
             ])
         })
@@ -12,7 +12,7 @@ module.exports = {
     down: async (queryInterface, Sequelize) => {
         return queryInterface.sequelize.transaction(t => {
             return Promise.all([
-                queryInterface.removeColumn('Rates', 'currency', { transaction: t })
+                queryInterface.removeColumn('TimeEntries', 'toggl_id', { transaction: t })
             ])
         })
     }

--- a/api/models/TimeEntry.js
+++ b/api/models/TimeEntry.js
@@ -19,7 +19,7 @@ module.exports = (sequelize) => {
             allowNull: false
         },
         toggl_id: {
-            type: DataTypes.INTEGER,
+            type: DataTypes.BIGINT,
             allowNull: false,
             unique: true
         },


### PR DESCRIPTION
**Issue #529**
**Description**
When some toggl_id surpassed the int limit we get a sequelize error.

- Modify the type of toggl_id to bigint

![imagen](https://user-images.githubusercontent.com/36824674/135547196-aed976ec-4967-4091-ab0f-d9c32711a653.png)

