### PR TITLE
Change color of the clear icon inside Search component in ProjectContributors

### DIFF
--- a/src/components/ContributorList.js
+++ b/src/components/ContributorList.js
@@ -1,14 +1,16 @@
-import React, { useState, useEffect, useMemo, Suspense } from 'react'
+import React, { useState, useMemo, Suspense } from 'react'
 import {
     Grid,
     Box,
     TextField,
-    Typography
+    Typography,
+    IconButton
 } from '@material-ui/core'
 import ContributorsEmptyState from './ContributorsEmptyState'
 import AllocationAddForm from './AllocationAddForm'
 import { differenceBy } from 'lodash'
 import GithubAccessBlocked from './GithubAccessBlocked'
+import { CancelRounded } from '@material-ui/icons'
 
 const ContributorList = (props) => {
 
@@ -69,20 +71,29 @@ const ContributorList = (props) => {
     }
 
     return (
-        <Grid container className='ProjectContributors'>
+        <Grid container className='ContributorList'>
             <h1>
                 {`${project.name} Contributors`}
             </h1>
             <Grid xs={12}/>
             <Grid item xs={12} sm={5}>
                 <TextField
+                    className='input'
                     placeholder='Search contributors...' 
                     onChange={(event) => { setSearch(event.target.value) }}
                     fullWidth
+                    value={search}
                     color='primary'
                     variant='outlined'
-                    type={'search'}
-                    id='search'
+                    InputProps={{
+                        endAdornment: search && (
+                            <CancelRounded 
+                                className='cancel-icon'
+                                color='primary'
+                                onClick={() => setSearch('')}
+                            />
+                        )
+                    }}
                 />
             </Grid>
             <Grid xs={12}/>

--- a/src/styles/ContributorList.scss
+++ b/src/styles/ContributorList.scss
@@ -1,0 +1,11 @@
+.ContributorList {
+    .cancel-icon{
+        cursor: pointer;
+    }
+}
+
+@media screen and (min-width: $sm) {
+    .ContributorList {
+        
+    }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -47,3 +47,4 @@ code {
 @import './DateInput.scss';
 @import './ProjectSummary.scss';
 @import './AllocationTile.scss';
+@import './ContributorList.scss';


### PR DESCRIPTION
**Issue #522**
**Description**
The color from the clear icon was a color that was not from the palette, with this change the icon is different and the color is the SetLife blue.

**Proof**
![image](https://user-images.githubusercontent.com/86666889/136851506-d914b9d7-06df-4d5e-81a0-c11d0ed30423.png)

**What color do you think that looks better for the clear Icon? Blue, black, or grey?**

**Should we change the clear icon to any of these options?**
![image](https://user-images.githubusercontent.com/86666889/136851698-f5dea7f5-7815-4dfe-9f04-11a17e7285c1.png)

**Should we add the search icon at the start of the search bar?**
![image](https://user-images.githubusercontent.com/86666889/136851879-a41eb4d2-e6d9-4ed3-b142-0c2aae12501e.png)
