### PR TITLE
Reloading contributors page bug

### DIFF
--- a/src/components/GithubAccessBlocked.js
+++ b/src/components/GithubAccessBlocked.js
@@ -1,28 +1,35 @@
-import React from 'react'
+import React, {useEffect, useState} from 'react'
 import {
     Box,
     Grid,
     Typography,
     Link
 } from '@material-ui/core'
-import { useQuery } from '@apollo/client';
+import {useLazyQuery, useQuery} from '@apollo/client';
 import { GET_PROJECT } from '../operations/queries/ProjectQueries';
 
 const GithubAccessBlocked = (props) => {
 
     const githubURL = props.githubURL
-
-    const {
+    
+    const [project, setProject] = useState(null)
+    
+    const [getProject, {
         data: dataProject,
         loading: loadingProject,
         error: errorProject,
-    } = useQuery(GET_PROJECT, {
-        variables: {
-            id: Number(props.projectId)
+    }] = useLazyQuery(GET_PROJECT, {
+        onCompleted: dataProject => {
+            setProject(dataProject.getProjectById.github_url)
         }
     })
 
-    const projectURL = dataProject.getProjectById.github_url
+    useEffect(() => {
+        getProject({
+            variables: { id: Number(props.projectId) }
+        })
+    }, [dataProject])
+
 
     return (
         <Grid container className='GithubAccessBlocked'>
@@ -32,7 +39,7 @@ const GithubAccessBlocked = (props) => {
                         {props.message}
                     </Typography>
                     <Typography align='center' variant='h6'>
-                        <Link href={projectURL}>
+                        <Link href={project}>
                             Open in Github
                         </Link>
                     </Typography>

--- a/src/components/GithubAccessBlocked.js
+++ b/src/components/GithubAccessBlocked.js
@@ -12,7 +12,7 @@ const GithubAccessBlocked = (props) => {
 
     const githubURL = props.githubURL
     
-    const [project, setProject] = useState(null)
+    const [projectGithubUrl, setProjectGithubUrl] = useState(null)
     
     const [getProject, {
         data: dataProject,
@@ -20,7 +20,7 @@ const GithubAccessBlocked = (props) => {
         error: errorProject,
     }] = useLazyQuery(GET_PROJECT, {
         onCompleted: dataProject => {
-            setProject(dataProject.getProjectById.github_url)
+            setProjectGithubUrl(dataProject.getProjectById.github_url)
         }
     })
 
@@ -30,7 +30,6 @@ const GithubAccessBlocked = (props) => {
         })
     }, [dataProject])
 
-
     return (
         <Grid container className='GithubAccessBlocked'>
             <Grid item xs={12}>
@@ -39,7 +38,7 @@ const GithubAccessBlocked = (props) => {
                         {props.message}
                     </Typography>
                     <Typography align='center' variant='h6'>
-                        <Link href={project}>
+                        <Link href={projectGithubUrl}>
                             Open in Github
                         </Link>
                     </Typography>


### PR DESCRIPTION
**Issue #506**
**Description**

When reloading de contributord page of a project where you doen't have all the permissions, the page crashed.
We fixed modifying the query for getting the project url to use a lazy query.

**Implementation proof**
https://www.loom.com/share/abc9819c43e246be87de25caad977c55