### PR TITLE
Allocation info only displaying max budget and not monthly rate in project payment page

### DIFF
--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -121,8 +121,6 @@ const PaymentTile = (props) => {
                 currencyInformation: currencyInformation
             })
             
-            console.log(rate.type)
-
             return (
                 <Box 
                     mb={3} 


### PR DESCRIPTION
**Issue #330**
**Description**
On the ProjectPayment page, every allocation was displaying the rate as max budget and there was no one with a monthly rate when most of the allocations use monthly rate.

**Proof**
![image](https://user-images.githubusercontent.com/86666889/138131448-ef8d4e0d-cf29-4bad-b641-ee59b4d90ad6.png)
