### PR TITLE
Improve PaymentTile on ClientPage

### DIFF
--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -247,6 +247,17 @@ const PaymentTile = (props) => {
                                         <DeleteOutlinedIcon color='primary'/>
                                     </Button>
                                 </Grid>
+                                <Grid item xs={12} align='center'>
+                                    <Button
+                                        color='primary'
+                                        variant='outlined'
+                                        onClick={() => addAllocation({ payment })}
+                                    >
+                                        <Typography>
+                                            {`Allocate`}
+                                        </Typography>
+                                    </Button>
+                                </Grid>
                             </Grid>
                         </Box>
                     }
@@ -276,7 +287,7 @@ const PaymentTile = (props) => {
                     }
                 </Accordion>
             </Box>
-            {(paymentClicked && project) &&
+            {paymentClicked &&
                 <AllocationAddForm
                     client={client}
                     project={project ? project : null}

--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -7,14 +7,14 @@ import {
     AccordionSummary,
     Box,
     Button,
-    Fab,
     Grid,
     Typography
 } from '@material-ui/core/'
 import DeleteOutlinedIcon from '@material-ui/icons/DeleteOutlined';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import MonetizationOnIcon from '@material-ui/icons/MonetizationOn'
-import EditIcon from '@material-ui/icons/Edit';
+import EditIcon from '@material-ui/icons/Edit'
+import EditIconOutlined from '@material-ui/icons/EditOutlined'
 
 import AllocationAddForm from './AllocationAddForm'
 import AllocationOverview from './AllocationOverview'
@@ -28,7 +28,6 @@ import {
     formatAmount,
     selectCurrencyInformation
 } from '../scripts/selectors'
-import { red } from '../styles/colors.scss'
 
 const PaymentTile = (props) => {
 
@@ -188,27 +187,28 @@ const PaymentTile = (props) => {
                         }}
                     >
                         <Grid container alignItems='center'>
-                            <Grid item xs={8} align='left'>
+                            <Grid item xs={6} align='left'>
                                 <Typography variant='h6'>
                                     {`${paymentAmount}`}
                                 </Typography>
                             </Grid>
-                            <Grid item xs={4} align='right'>
+                            <Grid item xs={5} align='right'>
+                                <Box mb={0.75}>
+                                    <Typography
+                                        variant='caption'
+                                        color='secondary'
+                                    >
+                                        {`${paymentHasBeenMade
+                                            ? formattedDatePaid
+                                            : formattedDateIncurred}`
+                                        }
+                                    </Typography>
+                                </Box>
+                            </Grid>
+                            <Grid item xs={1} align='right'>
                                 <MonetizationOnIcon
                                     color={`${paymentHasBeenMade ? 'primary' : 'secondary'}`}
                                 />
-                            </Grid>
-                            <Grid item xs={8}>
-                                <Typography
-                                    variant='caption'
-                                    align='left'
-                                    color='secondary'
-                                >
-                                    {`${paymentHasBeenMade
-                                        ? formattedDatePaid
-                                        : formattedDateIncurred}`
-                                    }
-                                </Typography>
                             </Grid>
                             {project &&
                                 <Grid item xs={12}>
@@ -230,24 +230,7 @@ const PaymentTile = (props) => {
                     {!project &&
                         <Box align='left' mb={2} ml={2}>
                             <Grid container>
-                                <Grid item xs={6}>
-                                    <Button
-                                        color='primary'
-                                        onClick={() => handleEditPayment(true)}
-                                        disabled={payment.external_uuid_type}
-                                    >
-                                        {'Edit Payment'.toUpperCase()}
-                                    </Button>
-                                </Grid>
-                                <Grid item xs={6} align='right'>
-                                    <Button
-                                        color='primary'
-                                        onClick={() => handleDeletePayment(true)}
-                                    >
-                                        <DeleteOutlinedIcon color='primary'/>
-                                    </Button>
-                                </Grid>
-                                <Grid item xs={12} align='center'>
+                                <Grid item xs={8}>
                                     <Button
                                         color='primary'
                                         variant='outlined'
@@ -256,6 +239,23 @@ const PaymentTile = (props) => {
                                         <Typography>
                                             {`Allocate`}
                                         </Typography>
+                                    </Button>
+                                </Grid>
+                                <Grid item xs={2} align='right'>
+                                    <Button
+                                        color='primary'
+                                        onClick={() => handleEditPayment(true)}
+                                        disabled={payment.external_uuid_type}
+                                    >
+                                        <EditIconOutlined />
+                                    </Button>
+                                </Grid>
+                                <Grid item xs={2} align='right'>
+                                    <Button
+                                        color='primary'
+                                        onClick={() => handleDeletePayment(true)}
+                                    >
+                                        <DeleteOutlinedIcon color='primary'/>
                                     </Button>
                                 </Grid>
                             </Grid>


### PR DESCRIPTION
**Issue #554**
**Description**
In `ClientPage` the user should be able to allocate a contributor from the `PaymentTile`.

**Proof**
![image](https://user-images.githubusercontent.com/86666889/140086902-ff87be74-724f-4933-a089-b0a9bd33934c.png)

**Feedback**
1) Where should I place the Allocate button?
2) What do you think of moving the Date next to the amount?
 Right now it looks like this 
![image](https://user-images.githubusercontent.com/86666889/140087197-5727e331-9880-4bd5-b285-34ee42bb4030.png)

 How It would look if we move the Date next to the amount
![image](https://user-images.githubusercontent.com/86666889/140087444-bc70de13-2826-4657-aa98-b9f7e67b758a.png)
