### PR TITLE
Use finalize_at instead of updating the created at timestamp on invoice webhooks.

### DIFF
--- a/api/modules/budgeting.js
+++ b/api/modules/budgeting.js
@@ -32,7 +32,7 @@ const budgeting = module.exports = (() => {
             const dateIncurredOverride = stripeInvoice.metadata?.date_incurred
                 ? moment(stripeInvoice.metadata.date_incurred, 'YYYY-MM-DD')
                 : stripeInvoice.status_transitions?.finalized_at
-                    ? moment.unix(stripeInvoice.status_transitions.finalized_at, 'x').utc()
+                    ? moment.unix(stripeInvoice.status_transitions.finalized_at, 'X')
                     : moment(stripeInvoice.created, 'X')
 
             const datePaidOverride = stripeInvoice.metadata?.date_paid
@@ -146,7 +146,7 @@ const budgeting = module.exports = (() => {
             if (dateIncurredOverride) {
                 updatedAttributes.date_incurred = dateIncurredOverride
             } else if (finalizedAt) {
-                updatedAttributes.date_incurrred = moment(finalizedAt).format()
+                updatedAttributes.date_incurred = moment(finalizedAt).format('YYYY-MM-DD')
             }
 
             await db.models.Payment.update({

--- a/api/modules/budgeting.js
+++ b/api/modules/budgeting.js
@@ -32,7 +32,7 @@ const budgeting = module.exports = (() => {
             const dateIncurredOverride = stripeInvoice.metadata?.date_incurred
                 ? moment(stripeInvoice.metadata.date_incurred, 'YYYY-MM-DD')
                 : stripeInvoice.status_transitions?.finalized_at
-                    ? moment(stripeInvoice.status_transitions.finalized_at).format()
+                    ? moment.unix(stripeInvoice.status_transitions.finalized_at, 'x').utc()
                     : moment(stripeInvoice.created, 'X')
 
             const datePaidOverride = stripeInvoice.metadata?.date_paid


### PR DESCRIPTION
**Issue #546**
**Description**

When a Stripe invoice is finalized and set to ready_to_allocate to be triggered by the webhook to create a Payment, the logic correctly brings in the date_incurred data when creating or updating the Trinary Payment. If provided in the metadata, it uses the override value or defaults to the Invoice creation timestamp if an override is not provided.

Before defaulting to the created_at timestamp we should use finalized_at if available

**Implementation proof**
https://www.loom.com/share/1cc940561a344743824c2d40230fb269