### PR TITLE
Start/end date when adding an allocation.

### DIFF
--- a/src/components/AllocationAddForm.js
+++ b/src/components/AllocationAddForm.js
@@ -204,7 +204,7 @@ const AllocationAddForm = (props) => {
     const [newAllocationRate, setNewAllocationRate] = useState({})
     const [newAllocation, setNewAllocation] = useState({})
     const [rateCurrency, setRateCurrency] = useState(null)
-    const [startDate, setStartDate] = useState(moment().add(1, 'months').startOf('month').utc())
+    const [startDate, setStartDate] = useState(moment().add(1, 'months').startOf('month'))
     const [endDate, setEndDate] = useState(moment().add(1, 'months').endOf('month'))
     const [selectedContributor, setSelectedContributor] = useState(null)
     const [selectedProject, setSelectedProject] = useState(null)


### PR DESCRIPTION
**Issue #550**
**Description**

We check if the `.utc` is necessary on the start/end date when adding an allocation.
So we test with the utc and without it and the result its the same because we are not setting an specific time (hh:mm:ss), so we deleted the `.utc` 

**Implementation proof**
With the `.utc` on start/end date
![imagen](https://user-images.githubusercontent.com/36824674/141230453-a28ec15a-11a5-498c-bccd-ac7d66a9d17d.png)

Without the `.utc` on start/end date
![imagen](https://user-images.githubusercontent.com/36824674/141230501-12a26328-91bb-4789-8769-c51a18ed0a59.png)

![imagen](https://user-images.githubusercontent.com/36824674/141230651-94cd5473-437d-4def-9d5b-64bb12d29343.png)
