### PR TITLE
Allocations cannot be edited if the dates have changed

### DIFF
--- a/src/components/AllocationOverview.js
+++ b/src/components/AllocationOverview.js
@@ -232,7 +232,8 @@ const AllocationOverview = (props) => {
         updatedAllocationRate.total_amount == allocationInfo.amount &&
         updatedAllocationRate.hourly_rate == allocationInfo.rate.hourly_rate &&
         updatedAllocationPayment?.id == allocationInfo.payment?.id &&
-        updatedAllocationEndDate == allocationInfo.end_date
+        updatedAllocationEndDate == allocationInfo.end_date ||
+        updatedAllocationStartDate == allocationInfo.start_date
     )
     return (
         <Dialog

--- a/src/components/AllocationOverview.js
+++ b/src/components/AllocationOverview.js
@@ -231,9 +231,9 @@ const AllocationOverview = (props) => {
     const editButtonDisabled = (
         updatedAllocationRate.total_amount == allocationInfo.amount &&
         updatedAllocationRate.hourly_rate == allocationInfo.rate.hourly_rate &&
-        updatedAllocationPayment?.id == allocationInfo.payment?.id
+        updatedAllocationPayment?.id == allocationInfo.payment?.id &&
+        updatedAllocationEndDate == allocationInfo.end_date
     )
-
     return (
         <Dialog
             className='AllocationOverview'

--- a/src/components/AllocationOverview.js
+++ b/src/components/AllocationOverview.js
@@ -232,7 +232,7 @@ const AllocationOverview = (props) => {
         updatedAllocationRate.total_amount == allocationInfo.amount &&
         updatedAllocationRate.hourly_rate == allocationInfo.rate.hourly_rate &&
         updatedAllocationPayment?.id == allocationInfo.payment?.id &&
-        updatedAllocationEndDate == allocationInfo.end_date ||
+        updatedAllocationEndDate == allocationInfo.end_date &&
         updatedAllocationStartDate == allocationInfo.start_date
     )
     return (


### PR DESCRIPTION
**Issue #555**
**Description**

The Save button is disabled even if you change the start/end dates.

**Implementation proof**
https://www.loom.com/share/267658598e934d3cba67b97d973ee0fe?sharedAppSource=personal_library