### PR TITLE
Tweak ProjectPayment UI

### DIFF
--- a/src/components/ProjectPayments.js
+++ b/src/components/ProjectPayments.js
@@ -6,7 +6,8 @@ import {
     Fab,
     Grid,
     Typography,
-    Button
+    Button,
+    Divider
 } from '@material-ui/core'
 import AddIcon from '@material-ui/icons/Add'
 import { filter, isEmpty, orderBy } from 'lodash'
@@ -139,13 +140,16 @@ const ProjectPayments = (props) => {
                 {!isEmpty(proposedAllocations) &&
                     (
                         <Grid container>
-                            <Grid item xs={12} md={6}>
+                            <Grid item xs={12}>
                                 <Box mt={3} mb={5} pb={6}>
-                                    <ProjectProposedAllocationsTile
-                                        currencyInformation={currencyInformation}
-                                        proposedAllocations={proposedAllocations}
-                                        project={getProjectById}
-                                    />
+                                    <hr></hr>
+                                    <Box mt={3}>
+                                        <ProjectProposedAllocationsTile
+                                            currencyInformation={currencyInformation}
+                                            proposedAllocations={proposedAllocations}
+                                            project={getProjectById}
+                                        />
+                                    </Box>
                                 </Box>
                             </Grid>
                         </Grid>

--- a/src/components/ProjectPaymentsSummary.js
+++ b/src/components/ProjectPaymentsSummary.js
@@ -73,7 +73,7 @@ const ProjectPaymentsSummary = (props) => {
                         {`${totalAllocatedAmount} allocated`}
                     </Typography>
                     <Typography>
-                        {`${totalProfitAmount} on profit`}
+                        {`${totalProfitAmount} not allocated`}
                     </Typography>
                     <Typography>
                         {`${totalAllocatedNonConfirmedAmount} on allocations not confirmed`}


### PR DESCRIPTION
**Issue #356**
**Description**
The following changes for the ProjectPayement page:
- [x] on profit -> not allocated
- [x] Add invoices paid
- [x] Total proposed tile should be full width and add divider before it