### PR TITLE
Toggl url validation rules explained

### DIFF
--- a/src/components/AddProjectForm.js
+++ b/src/components/AddProjectForm.js
@@ -28,6 +28,7 @@ import { EXPECTED_BUDGET_TIMEFRAME_OPTIONS } from '../constants'
 import { GET_CLIENT_INFO } from '../operations/queries/ClientQueries'
 import { ADD_PROJECT, SYNC_TOGGL_PROJECT } from '../operations/mutations/ProjectMutations'
 import { CREATE_PERMISSION } from '../operations/mutations/PermissionMutations'
+import { INVALID_TOGGL_URL_ERROR_MESSAGE } from '../constants'
 
 const AddProjectForm = (props) => {
 
@@ -118,8 +119,7 @@ const AddProjectForm = (props) => {
         }
         if (projectToggl) {
             if (!verifyTogglURL(projectToggl)) {
-                setCreateProjectError('The Toggl URL is invalid.')
-                setCreateProjectError('Please follow the following format https://track.toggl.com/###/projects/###')
+                setCreateProjectError(INVALID_TOGGL_URL_ERROR_MESSAGE)
                 setDisplayError(true)
                 return
             }

--- a/src/components/AddProjectForm.js
+++ b/src/components/AddProjectForm.js
@@ -118,7 +118,8 @@ const AddProjectForm = (props) => {
         }
         if (projectToggl) {
             if (!verifyTogglURL(projectToggl)) {
-                setCreateProjectError('The Toggl URL is invalid')
+                setCreateProjectError('The Toggl URL is invalid.')
+                setCreateProjectError('Please follow the following format https://track.toggl.com/###/projects/###')
                 setDisplayError(true)
                 return
             }

--- a/src/components/ProjectEditDialog.js
+++ b/src/components/ProjectEditDialog.js
@@ -99,7 +99,7 @@ const ProjectEditDialog = (props) => {
         }
         if (togglURL) {
             if (!verifyTogglURL(togglURL)) {
-                setEditProjectError('The Toggl URL is invalid')
+                setEditProjectError('Toggl URL is invalid, please follow the following format https://track.toggl.com/###/projects/###')
                 setDisplayError(true)
                 return
             }

--- a/src/components/ProjectEditDialog.js
+++ b/src/components/ProjectEditDialog.js
@@ -34,7 +34,7 @@ import {
 
 import { SYNC_TOGGL_PROJECT, UPDATE_PROJECT } from '../operations/mutations/ProjectMutations'
 import { EXPECTED_BUDGET_TIMEFRAME_OPTIONS, MAX_INT } from '../constants'
-
+import { INVALID_TOGGL_URL_ERROR_MESSAGE } from '../constants'
 
 const ProjectEditDialog = (props) => {
 
@@ -99,7 +99,7 @@ const ProjectEditDialog = (props) => {
         }
         if (togglURL) {
             if (!verifyTogglURL(togglURL)) {
-                setEditProjectError('Toggl URL is invalid, please follow the following format https://track.toggl.com/###/projects/###')
+                setEditProjectError(INVALID_TOGGL_URL_ERROR_MESSAGE)
                 setDisplayError(true)
                 return
             }

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -164,3 +164,4 @@ export const TIME_RANGES = [
         since: 1
     }
 ]
+export const INVALID_TOGGL_URL_ERROR_MESSAGE = 'Please follow the following format https://track.toggl.com/###/projects/###'

--- a/src/scripts/selectors.js
+++ b/src/scripts/selectors.js
@@ -120,7 +120,7 @@ export const verifyGithubURL = (url) => {
 }
 export const verifyTogglURL = (url) => {
     const togglLinkInformation = split(url, '/')
-    if (togglLinkInformation.length < 6) {
+    if (togglLinkInformation.length < 6 || togglLinkInformation.length > 7) {
         return 0
     }
     return 1


### PR DESCRIPTION
**issue #361**
**Description**

When the user set the toggl url incorrectly it is still confusing and they would not know about the validation rules.

Updated the error popup message.

![imagen](https://user-images.githubusercontent.com/36824674/143503671-70a91638-9cd8-44c3-b525-6b166c89385f.png)
