### PR TITLE
Delete workspace id from enviroment variables.

### DIFF
--- a/api/config/credentials.js
+++ b/api/config/credentials.js
@@ -17,8 +17,7 @@ module.exports = {
         SECRET: process.env.STRIPE_SECRET,
     },
     TOGGL: {
-        API_KEY: process.env.TOGGL_API_KEY,
-        WORKSPACE_ID: process.env.TOGGL_WORKSPACE_ID
+        API_KEY: process.env.TOGGL_API_KEY
     },
     // MYSQL Access Keys
     MYSQL: {


### PR DESCRIPTION
**Issue #136**
**Description**

Delete the constant `WORKSPACE_ID` since is never used and the enviroment variable has already been deleted.