### PR TITLE
Display user avatar in IssueTile

### DIFF
--- a/api/migrations/20220127160659-addAvatarFieldToContributor.js
+++ b/api/migrations/20220127160659-addAvatarFieldToContributor.js
@@ -1,0 +1,21 @@
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        return queryInterface.sequelize.transaction(t => {
+            return Promise.all([
+                queryInterface.addColumn('Contributors', 'avatar_url', {
+                    type: Sequelize.DataTypes.STRING
+                }, { transaction: t })
+            ])
+        })
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        return queryInterface.sequelize.transaction(t => {
+            return Promise.all([
+                queryInterface.addColumn('Contributors', 'avatar_url', {
+                    type: Sequelize.DataTypes.STRING
+                }, { transaction: t })
+            ])
+        })
+    }
+}

--- a/api/models/Contributor.js
+++ b/api/models/Contributor.js
@@ -35,6 +35,10 @@ module.exports = (sequelize) => {
         github_access_token: {
             type: DataTypes.STRING,
             unique: true
+        },
+        avatar_url: {
+            type: DataTypes.STRING,
+            unique: true
         }
     },
     {

--- a/api/modules/authentication.js
+++ b/api/modules/authentication.js
@@ -13,7 +13,8 @@ const authentication = module.exports = (() => {
             name: githubContributor.name ? githubContributor.name : githubContributorUsername,
             github_id: githubContributor.id,
             github_handle: githubContributor.githubUrl,
-            github_access_token: githubContributor.accessToken
+            github_access_token: githubContributor.accessToken,
+            avatar_url: githubContributor.avatar_url
         })
     }
 

--- a/api/modules/dataSyncs.js
+++ b/api/modules/dataSyncs.js
@@ -94,7 +94,8 @@ const dataSyncs = module.exports = (() => {
                         await db.models.Contributor.create({
                             name: contributorInfo.name ? contributorInfo.name : c.login,
                             github_id: c.id,
-                            github_handle: c.html_url
+                            github_handle: c.html_url,
+                            avatar_url: c.avatar_url
                         })
                     )
                 }

--- a/api/schema/types/ContributorType.js
+++ b/api/schema/types/ContributorType.js
@@ -10,6 +10,7 @@ module.exports = gql`
         github_id: String
         github_handle: String
         github_access_token: String
+        avatar_url: String
         allocations: [Allocation]
         permissions: [Permission]
         timeEntries: [TimeEntry]
@@ -27,6 +28,7 @@ module.exports = gql`
         external_data_url: String
         github_id: String
         github_handle: String
+        avatar_url: String
     }
 
     input UpdateContributorInput {
@@ -38,6 +40,7 @@ module.exports = gql`
         external_data_url: String
         github_id: String
         github_handle: String
+        avatar_url: String
     }
 
     type ContributorOrganizations {

--- a/src/components/IssueTile.js
+++ b/src/components/IssueTile.js
@@ -14,8 +14,6 @@ const IssueTile = (props) => {
     const { issue } = props
     const issueIsOpen = issue.date_closed ? false : true
 
-    console.log(issue)
-
     const renderContributions = (contributions) => {
         return contributions.map(i => {
             return (

--- a/src/components/IssueTile.js
+++ b/src/components/IssueTile.js
@@ -2,7 +2,9 @@ import React, { useState } from 'react'
 import {
     Box,
     Grid,
-    Typography
+    Avatar,
+    Typography,
+    Tooltip
 } from '@material-ui/core'
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward'
 import moment from 'moment'
@@ -12,24 +14,16 @@ const IssueTile = (props) => {
     const { issue } = props
     const issueIsOpen = issue.date_closed ? false : true
 
+    console.log(issue)
+
     const renderContributions = (contributions) => {
         return contributions.map(i => {
             return (
-                <Grid item xs={12} mt={1} align='left'>
+                <Tooltip title={i.contributor.github_handle}>
                     <Box>
-                        {i.is_author
-                            ? (
-                                <Typography color='secondary'>
-                                    {`Author: ${i.contributor.github_handle}`}
-                                </Typography>
-                            ) : (
-                                <Typography color='secondary'>
-                                    {`Assigned: ${i.contributor.github_handle}`}
-                                </Typography>
-                            )
-                        }
+                        <Avatar alt='Avatar' src={i.contributor.avatar_url}/>
                     </Box>
-                </Grid>
+                </Tooltip>
             )
         })
     }
@@ -83,10 +77,20 @@ const IssueTile = (props) => {
                         </Typography>
                     </Box>
                 </Grid>
-                <Grid container>
-                    {renderContributions(issue.contributions)}
+                <Grid item xs={12}>
+                    <Grid container spacing={1}>
+                        <Grid item>
+                            <Box mt={1}>
+                                <Typography color='secondary'>
+                                    {`Contributors:`}
+                                </Typography>
+                            </Box>
+                        </Grid>
+                        <Grid item>
+                            {renderContributions(issue.contributions)}
+                        </Grid>
+                    </Grid>
                 </Grid>
-
                 <Grid item xs={12} align='left'/>
                 <Grid item xs={6}>
                     <Box mt={2}>

--- a/src/components/IssueTile.js
+++ b/src/components/IssueTile.js
@@ -20,7 +20,7 @@ const IssueTile = (props) => {
         return contributions.map(i => {
             return (
                 <Tooltip title={i.contributor.github_handle}>
-                    <Box>
+                    <Box mr={1}>
                         <Avatar alt='Avatar' src={i.contributor.avatar_url}/>
                     </Box>
                 </Tooltip>

--- a/src/operations/queries/ProjectQueries.js
+++ b/src/operations/queries/ProjectQueries.js
@@ -152,6 +152,7 @@ export const GET_PROJECT_ISSUES = gql`
                     contributor {
                         id
                         github_handle
+                        avatar_url
                     }
                 }
             }


### PR DESCRIPTION
**Issue #562**
**Description**
Instead of displaying the `github_handler` in `IssueTile`, the _avatar_ of the user should be displayed.

- [x] Create avatar_url database column.
- [x] Create a migration to add the column.
- [x] Use the avatar column to get the avatar_url in the `IssueTile` component.