### PR TITLE
Date Quick Select buttons crash the app when clicked

### DIFF
--- a/src/components/DateInput.js
+++ b/src/components/DateInput.js
@@ -47,7 +47,7 @@ const DateInput = (props) => {
         } else if (years) {
             endingDate = moment(startDate).add(years, 'years')
         }
-        setEndDate(endingDate.toDate())
+        setEndDate(endingDate)
     }
 
     const renderWeeks = () => {


### PR DESCRIPTION
**Issue #616**
**Description**
When selecting any button from **Date Quick Select** the app crash

**Solution**
When debugging the app we can see that `startDate` and `endDate` have different properties. So using `.format` in `endDate` was making the app crash. 
The solution is to remove `toDate()` function so `endDate` can have the same properties as `startDate`
![image](https://user-images.githubusercontent.com/86666889/167685563-b45b0223-ec74-402a-848b-64446851d7de.png)

**Implementation proof**
<a href="https://www.loom.com/share/9aa6c73586c943a3ae3971fbdc8c0708">
    <p>Trinary: Date quick select buttons crash the app fix - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/9aa6c73586c943a3ae3971fbdc8c0708-with-play.gif">
  </a>