### PR TITLE
Improve Allocation information on PaymentTiles

### DIFF
--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -93,7 +93,9 @@ const PaymentTile = (props) => {
 
     const { allocations } = dataPaymentAllocations.getPaymentById
     const orderedAllocations = orderBy(allocations, ['project.name'], ['desc'])
-    const filteredAllocations = project ? filter(allocations, ['project.name', project.name]) : null
+    const filteredAllocations = project 
+        ? filter(allocations, ['project.name', project.name]) 
+        : null
     const totalAllocated = formatAmount({
         amount: dataTotalAllocated.getPaymentById.totalAllocated / 100,
         currencyInformation: currencyInformation
@@ -103,7 +105,9 @@ const PaymentTile = (props) => {
         currencyInformation: currencyInformation
     })
     const numberOfContributorsAllocated = allocations.length
-    const numberOfFilteredContributorsAllocated = project ? filteredAllocations.length : null
+    const numberOfFilteredContributorsAllocated = project 
+        ? filteredAllocations.length 
+        : null
     
     const totalProjectAllocations = () => {
         let total = 0
@@ -224,7 +228,7 @@ const PaymentTile = (props) => {
                 <Accordion>
                     <AccordionSummary
                         expandIcon={
-                            <Grid item xs={1}>
+                            <Grid item xs={0.5}>
                                 <ExpandMoreIcon />
                             </Grid>
                         }
@@ -265,15 +269,22 @@ const PaymentTile = (props) => {
                                     color={`${!totalAllocated || totalAllocated > payment.amount ? 'red' : 'primary.main'}`}
                                 >
                                     <Typography variant='subtitle2'>
-                                        {`${project ? totalAllocatedContributors : totalAllocated} allocated`}
-                                        <br/>
-                                        {`to ${project ? numberOfFilteredContributorsAllocated : numberOfContributorsAllocated} ${numberOfContributorsAllocated == 1 ? 'contributor' : 'contributors'}`}
+                                        {`${project ? totalAllocatedContributors : totalAllocated} allocated `}
+                                        {
+                                            (
+                                                `to 
+                                                ${project 
+                                                    ? numberOfFilteredContributorsAllocated 
+                                                    : numberOfContributorsAllocated} 
+                                                ${numberOfContributorsAllocated == 1 || numberOfFilteredContributorsAllocated == 1
+                                                    ? 'contributor' 
+                                                    : 'contributors'}`
+                                            )
+                                        }
                                     </Typography>
                                     {project && (calculateAllocationsOtherProjects() > 0 ) &&
-                                    <Typography variant='subtitle2'>
-                                        {`${totalAllocatedOtherProjects} allocated`}
-                                        <br/>
-                                        {`to other projects`}
+                                    <Typography variant='subtitle2' color='secondary'>
+                                        {`${totalAllocatedOtherProjects} to other projects`}
                                     </Typography>
                                     }
                                 </Box>

--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -103,6 +103,31 @@ const PaymentTile = (props) => {
         currencyInformation: currencyInformation
     })
     const numberOfContributorsAllocated = allocations.length
+    const numberOfFilteredContributorsAllocated = project ? filteredAllocations.length : null
+    
+    const totalProjectAllocations = () => {
+        let total = 0
+        filteredAllocations.map(f => {
+            total += (f.amount / 100)
+        })
+        return total
+    }
+    const totalAllocatedContributors = project 
+        ? (formatAmount({
+            amount: totalProjectAllocations(),
+            currencyInformation: currencyInformation
+        }))
+        : null
+
+    const calculateAllocationsOtherProjects = () => {
+        if (project) {
+            return dataTotalAllocated.getPaymentById.totalAllocated / 100 - totalProjectAllocations()
+        }
+    }
+    const totalAllocatedOtherProjects = formatAmount({
+        amount: calculateAllocationsOtherProjects(),
+        currencyInformation: currencyInformation
+    })
 
     const renderPaymentAllocations = (props) => {
 
@@ -240,10 +265,17 @@ const PaymentTile = (props) => {
                                     color={`${!totalAllocated || totalAllocated > payment.amount ? 'red' : 'primary.main'}`}
                                 >
                                     <Typography variant='subtitle2'>
-                                        {`${totalAllocated} allocated`}
+                                        {`${project ? totalAllocatedContributors : totalAllocated} allocated`}
                                         <br/>
-                                        {`to ${numberOfContributorsAllocated} ${numberOfContributorsAllocated == 1 ? 'contributor' : 'contributors'}`}
+                                        {`to ${project ? numberOfFilteredContributorsAllocated : numberOfContributorsAllocated} ${numberOfContributorsAllocated == 1 ? 'contributor' : 'contributors'}`}
                                     </Typography>
+                                    {project && (calculateAllocationsOtherProjects() > 0 ) &&
+                                    <Typography variant='subtitle2'>
+                                        {`${totalAllocatedOtherProjects} allocated`}
+                                        <br/>
+                                        {`to other projects`}
+                                    </Typography>
+                                    }
                                 </Box>
                             </Grid>
                         </Grid>

--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { useQuery } from '@apollo/client'
 import moment from 'moment'
+import { orderBy, filter } from 'lodash'
 import {
     Accordion,
     AccordionDetails,
@@ -91,6 +92,8 @@ const PaymentTile = (props) => {
     if (errorTotalAllocated || errorPaymentAllocations) return `An error ocurred`
 
     const { allocations } = dataPaymentAllocations.getPaymentById
+    const orderedAllocations = orderBy(allocations, ['project.name'], ['desc'])
+    const filteredAllocations = project ? filter(allocations, ['project.name', project.name]) : null
     const totalAllocated = formatAmount({
         amount: dataTotalAllocated.getPaymentById.totalAllocated / 100,
         currencyInformation: currencyInformation
@@ -101,14 +104,14 @@ const PaymentTile = (props) => {
     })
     const numberOfContributorsAllocated = allocations.length
 
-    const projectName = (allocations.length > 0) ? allocations[0].project.name : ''
-    
     const renderPaymentAllocations = (props) => {
 
         const {
             allocations,
             currencyInformation
         } = props
+        const projects = []
+        let projectTitle = null
 
         return allocations.map((a, i) => {
             const {
@@ -117,17 +120,35 @@ const PaymentTile = (props) => {
                 end_date,
                 rate
             } = a
+            const projectName = a.project.name
             const paymentAmount = formatAmount({
                 amount: parseFloat(amount / 100).toFixed(2),
                 // amount: parseFloat((amount / 100).toFixed(2)).toString(),
                 currencyInformation: currencyInformation
             })
-            
+
+            if (!projects.includes(projectName) && !project) {
+                projects.push(projectName)
+                projectTitle = projectName
+            } else {
+                projectTitle = null
+            }
+
             return (
                 <Box 
                     mb={3} 
                     className='PaymentTile' 
                 >
+                    {!project &&
+                        <Grid item xs={12} align='center'>
+                            <Typography 
+                                variant='h6'
+                                className='project-name'
+                            >
+                                {projectTitle}
+                            </Typography>
+                        </Grid>
+                    }
                     <Grid
                         container
                         className='payments-grid'
@@ -230,17 +251,9 @@ const PaymentTile = (props) => {
                     {!project &&
                         <Box align='left' mb={2} mx={2}>
                             <Grid container>
-                                <Grid item xs={12} align='center'>
-                                    <Typography 
-                                        variant='h6'
-                                        className='project-name'
-                                    >
-                                        {projectName}
-                                    </Typography>
-                                </Grid>
                                 <Grid item xs={12}>
                                     {renderPaymentAllocations({
-                                        allocations: allocations,
+                                        allocations: orderedAllocations,
                                         currencyInformation: currencyInformation
                                     })}
                                 </Grid>
@@ -288,7 +301,7 @@ const PaymentTile = (props) => {
                             <Grid container>
                                 <Grid item xs={12}>
                                     {renderPaymentAllocations({
-                                        allocations: allocations,
+                                        allocations: filteredAllocations,
                                         currencyInformation: currencyInformation
                                     })}
                                 </Grid>

--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -140,7 +140,6 @@ const PaymentTile = (props) => {
             currencyInformation
         } = props
         const projects = []
-        let projectTitle = null
 
         return allocations.map((a, i) => {
             const {
@@ -156,11 +155,10 @@ const PaymentTile = (props) => {
                 currencyInformation: currencyInformation
             })
 
+            let projectTitle = null
             if (!projects.includes(projectName) && !project) {
                 projects.push(projectName)
                 projectTitle = projectName
-            } else {
-                projectTitle = null
             }
 
             return (


### PR DESCRIPTION
**Issue #644**
- [x] Allocations should be grouped by Project name on **Client Page**
- [x] Allocations only for this project should be displayed on **Project Page**
- [x] Make sure the total allocated only includes allocations for this project
- [x] Add text showing the total allocated to other project(s)