### PR TITLE
Do not allow deleting if the Payment has Allocations

### DIFF
--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -273,12 +273,22 @@ const PaymentTile = (props) => {
                                     </Tooltip>
                                 </Grid>
                                 <Grid item xs={2} align='right'>
-                                    <Button
-                                        color='primary'
-                                        onClick={() => handleDeletePayment(true)}
+                                    <Tooltip
+                                        title='This payment cannot be deleted because it has linked Allocations'
+                                        placement='top'
+                                        disableHoverListener={allocations.length > 0 ? false : true}
                                     >
-                                        <DeleteOutlinedIcon color='primary'/>
-                                    </Button>
+                                        <span>
+                                            <Button
+                                                color='primary'
+                                                onClick={() => handleDeletePayment(true)}
+                                                disabled={allocations.length ? true : false}
+                                            >
+                                                <DeleteOutlinedIcon />
+                                            </Button>
+                                        </span>
+                                    </Tooltip>
+
                                 </Grid>
                             </Grid>
                         </Box>


### PR DESCRIPTION
**Issue #646**
- [x] Show Tooltip when hovering the mouse on the delete button _"This payment cannot be deleted because it has linked Allocations"_
- [x] Disable delete button when the payment has allocations
- [x] Enable delete button when there are no allocations