### PR TITLE
Update Rates data model

### DIFF
--- a/api/migrations/20220609175823-createRoles.js
+++ b/api/migrations/20220609175823-createRoles.js
@@ -1,6 +1,6 @@
 module.exports = {
     up: async (queryInterface, Sequelize) => {
-        return queryInterface.createTable('Role', {
+        return queryInterface.createTable('Roles', {
             id: {
                 type: Sequelize.DataTypes.INTEGER,
                 primaryKey: true,
@@ -15,6 +15,6 @@ module.exports = {
     },
 
     down: async (queryInterface, Sequelize) => {
-        return queryInterface.dropTable('Contributions');
+        return queryInterface.dropTable('Roles');
     }
 };

--- a/api/migrations/20220609175823-createRoles.js
+++ b/api/migrations/20220609175823-createRoles.js
@@ -1,0 +1,20 @@
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        return queryInterface.createTable('Role', {
+            id: {
+                type: Sequelize.DataTypes.INTEGER,
+                primaryKey: true,
+                autoIncrement: true,
+                allowNull: false
+            },
+            name: {
+                type: Sequelize.DataTypes.STRING,
+                allowNull: false
+            }
+        });
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        return queryInterface.dropTable('Contributions');
+    }
+};

--- a/api/migrations/20220613204024-addNewFieldsToRate.js
+++ b/api/migrations/20220613204024-addNewFieldsToRate.js
@@ -1,0 +1,56 @@
+const moment = require('moment')
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        return queryInterface.sequelize.transaction(t => {
+            return Promise.all([
+                queryInterface.addColumn('Rates', 'minimum_expected_hours', {
+                    type: Sequelize.DataTypes.INTEGER(11),
+                    allowNull: true,
+                    defaultValue: null
+                }, { transaction: t }),
+                queryInterface.addColumn('Rates', 'maximum_expected_hours', {
+                    type: Sequelize.DataTypes.INTEGER(11),
+                    allowNull: true,
+                    defaultValue: null
+                }, { transaction: t }),
+                queryInterface.addColumn('Rates', 'minimum_hourly_rate', {
+                    type: Sequelize.DataTypes.STRING(15),
+                    allowNull: true,
+                    defaultValue: null
+                }, { transaction: t }),
+                queryInterface.addColumn('Rates', 'maximum_hourly_rate', {
+                    type: Sequelize.DataTypes.STRING(15),
+                    allowNull: true,
+                    defaultValue: null
+                }, { transaction: t }),
+                queryInterface.addColumn('Rates', 'role_id', {
+                    type: Sequelize.DataTypes.INTEGER(11),
+                    allowNull: true,
+                    defaultValue: null,
+                    references: {
+                        model: 'Roles',
+                        key: 'id'
+                    }
+                }, { transaction: t })
+            ])
+        })
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        return queryInterface.sequelize.transaction(t => {
+            return Promise.all([
+                queryInterface.removeColumn('Rates', 'minimum_expected_hours',
+                    { transaction: t }),
+                queryInterface.removeColumn('Rates', 'maximum_expected_hours',
+                    { transaction: t }),
+                queryInterface.removeColumn('Rates', 'minimum_hourly_rate',
+                    { transaction: t }),
+                queryInterface.removeColumn('Rates', 'maximum_hourly_rate',
+                    { transaction: t }),
+                queryInterface.removeColumn('Rates', 'role_id',
+                    { transaction: t }),
+            ])
+        })
+    }
+};

--- a/api/migrations/20220614155502-modifyTotalExpectedHoursAndHourlyRateDataType.js
+++ b/api/migrations/20220614155502-modifyTotalExpectedHoursAndHourlyRateDataType.js
@@ -1,0 +1,27 @@
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        return queryInterface.sequelize.transaction(t => {
+            return Promise.all([
+                queryInterface.changeColumn('Rates', 'total_expected_hours', {
+                    type: Sequelize.DataTypes.INTEGER(11)
+                }, { transaction: t }),
+                queryInterface.changeColumn('Rates', 'hourly_rate', {
+                    type: Sequelize.DataTypes.STRING(15)
+                }, { transaction: t })
+            ])
+        })
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        return queryInterface.sequelize.transaction(t => {
+            return Promise.all([
+                queryInterface.changeColumn('Rates', 'total_expected_hours', {
+                    type: Sequelize.DataTypes.INTEGER
+                }, { transaction: t }),
+                queryInterface.changeColumn('Rates', 'hourly_rate', {
+                    type: Sequelize.DataTypes.STRING
+                }, { transaction: t })
+            ])
+        })
+    }
+};

--- a/api/models/Role.js
+++ b/api/models/Role.js
@@ -1,0 +1,31 @@
+const Sequelize = require('sequelize')
+const { DataTypes, Deferrable } = require('sequelize')
+
+module.exports = (sequelize) => {
+
+    class Role extends Sequelize.Model {}
+
+    Role.init({
+        // Model attributes are defined here
+        id: {
+            type: DataTypes.INTEGER,
+            primaryKey: true,
+            autoIncrement: true,
+            allowNull: false
+        },
+        name: {
+            type: DataTypes.STRING,
+            allowNull: false
+        }
+    },
+    {
+        // Model options go here
+        sequelize,
+        modelName: 'Role',
+        createdAt: 'created_at',
+        updatedAt: 'updated_at'
+    });
+
+    return Role
+
+}

--- a/api/models/index.js
+++ b/api/models/index.js
@@ -47,6 +47,7 @@ const db = {
         Permission: require('./Permission')(sequelize),
         Project: require('./Project')(sequelize),
         Rate: require('./Rate')(sequelize),
+        Role: require('./Role')(sequelize),
         TimeEntry: require('./TimeEntry')(sequelize),
     }
 };
@@ -61,7 +62,8 @@ const associations = ({
     Payment, 
     Permission, 
     Project, 
-    Rate, 
+    Rate,
+    Role,
     TimeEntry
 }) => {
     Client.hasMany(Payment, { foreignKey: 'client_id' });
@@ -79,6 +81,7 @@ const associations = ({
     Project.hasMany(TimeEntry, { foreignKey: 'project_id' })
     Rate.hasMany(Allocation, { foreignKey: 'rate_id' })
     Rate.belongsTo(Contributor, { foreignKey: 'contributor_id' })
+    Role.hasMany(Rate, { foreignKey: 'role_id' })
 }
 
 associations(db.models)

--- a/api/schema/types/RateType.js
+++ b/api/schema/types/RateType.js
@@ -9,6 +9,10 @@ module.exports = gql`
         contributor_id: Int!
         total_expected_hours: Int
         currency: String
+        minimum_expected_hours: Int
+        minimum_hourly_rate: String
+        maximum_expected_hours: Int
+        maximum_hourly_rate: String
         contributor: Contributor
     }
 
@@ -19,6 +23,10 @@ module.exports = gql`
         type: String
         currency: String
         contributor_id: Int
+        minimum_expected_hours: Int
+        minimum_hourly_rate: String
+        maximum_expected_hours: Int
+        maximum_hourly_rate: String
     }
 
     type Query {


### PR DESCRIPTION
**Issue #640**
- [x] Create new `roles` table with fields:
1. id
2. name -VARCHAR(255)
3. create_at - default
4. updated_at default

- [x] Add new fields to `rates` table, all fields should be **NULLABLE** and default to _NULL_
1. minimum_expected_hours - INT(11)
2. maximum_expected_hours(11)
3. minimum_hourly_rate - VARCHAR(15)
4. maximum_hourly_rate VARCHAR(15)
5. role_id - INT(11) - default to NULL

- [x] Change `total_expeted_hours` datatype to match new minimum/maximum fields in rates table
- [x] Change `hourly_rate` datatype to match new minimum/maximum fields
- [x] Anywhere in the API that `hourly_rate` and `total_expected_hours` can be provided for a Rate+Allocation, allow these new fields to be provided