### PR TITLE
BTC invoice generation bug resolved

### DIFF
--- a/api/modules/paymentManagement.js
+++ b/api/modules/paymentManagement.js
@@ -54,7 +54,7 @@ const paymentManagement = module.exports = (() => {
             const isInvoiceExpired = invoice.status === `Expired`
             const isAmountUpdated = amountInSats != Number(invoice.amount)
             
-            if (external_uuid && !isInvoiceExpired && !isAmountUpdated) {
+            if (!isInvoiceExpired && !isAmountUpdated) {
                 throw new Error(`An active invoice already exists`)
             }
         }

--- a/api/modules/paymentManagement.js
+++ b/api/modules/paymentManagement.js
@@ -54,9 +54,10 @@ const paymentManagement = module.exports = (() => {
             ? Number((convertedAmount * 100000000).toFixed(0)) // 100M sats = 1 BTC
             : convertedAmount
         
-        const amountUpdated = amountInSats != await getBitcoinInvoiceAmount(external_uuid)
+        const amountUpdated = external_uuid && 
+        ( amountInSats != await getBitcoinInvoiceAmount(external_uuid) )
         
-        if (external_uuid && date_paid && !isInvoiceExpired && !amountUpdated) throw new Error(`An active invoice already exists`)
+        if (external_uuid && !isInvoiceExpired && !amountUpdated) throw new Error(`An active invoice already exists`)
             
         return createBitcoinInvoice(amountInSats)
     }


### PR DESCRIPTION
**Change 1**: `amountUpdated` checks if the amount for the current BTCPS invoice for the Payment is different from the Payment amount. To retrieve the BTCPS Invoice amount a request is sent to BTC Pay Server and `external_uuid` has the Invoice Id. Before sending the request, a check for whether the `external_uuid` exists was absent. Therefore, new Payments were sending requests with `external_uuid=null` and getting an error whereas Payments with pre-existing invoice could generate a new Invoice. A check for `external_uuid` was added for `amountUpdated`.

**Change 2**: `date_paid` need not exist to check if `An active invoice already exists`

