### PR TITLE
Link multi-project Allocations to Client Payments

### DIFF
--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -38,9 +38,11 @@ const PaymentTile = (props) => {
     const {
         client,
         payment,
-        project
+        project,
+        active
     } = props
 
+    localStorage.removeItem('openPayment')
     const formattedDatePaid = moment.utc(parseInt(payment.date_paid, 10)).format('MM/DD/YYYY')
     const formattedDateIncurred = moment.utc(parseInt(payment.date_incurred, 10)).format('MM/DD/YYYY')
     const paymentHasBeenMade = payment.date_paid != null
@@ -67,6 +69,7 @@ const PaymentTile = (props) => {
     const [openAllocationOverview, setOpenAllocationOverview] = useState(false)
     const [openDeletePayment, setOpenDeletePayment] = useState(false)
     const [selectedAllocation, setSelectedAllocation] = useState(null)
+    const [activeAccordion, setActiveAccordion] = useState(active)
 
     const addAllocation = (props) => {
         setOpenAddAllocationDialog(true)
@@ -84,6 +87,13 @@ const PaymentTile = (props) => {
     }
     const handleEditPayment = () => {
         history.push(`/clients/${client.id}/payments/${payment.id}/update`)
+    }
+    const handleRedirect = () => {
+        history.push(`/clients/${client.id}`)
+        localStorage.setItem('openPayment', payment.id)
+    }
+    const handleAccordion = () => {
+        setActiveAccordion(activeAccordion ? false : true)
     }
     const currencyInformation = selectCurrencyInformation({
         currency: client.currency
@@ -224,7 +234,10 @@ const PaymentTile = (props) => {
                 mx={1}
                 className='PaymentTile'
             >
-                <Accordion>
+                <Accordion 
+                    expanded={activeAccordion}
+                    onChange={() => handleAccordion()}
+                >
                     <AccordionSummary
                         expandIcon={
                             <Grid item xs={0.5}>
@@ -282,7 +295,12 @@ const PaymentTile = (props) => {
                                         }
                                     </Typography>
                                     {project && (calculateAllocationsOtherProjects() > 0 ) &&
-                                    <Typography variant='subtitle2' color='secondary'>
+                                    <Typography 
+                                        variant='subtitle2' 
+                                        color='secondary'
+                                        className='link'
+                                        onClick={() => handleRedirect()}
+                                    >
                                         {`${totalAllocatedOtherProjects} to other projects`}
                                     </Typography>
                                     }

--- a/src/components/PaymentTile.js
+++ b/src/components/PaymentTile.js
@@ -42,7 +42,6 @@ const PaymentTile = (props) => {
         active
     } = props
 
-    localStorage.removeItem('openPayment')
     const formattedDatePaid = moment.utc(parseInt(payment.date_paid, 10)).format('MM/DD/YYYY')
     const formattedDateIncurred = moment.utc(parseInt(payment.date_incurred, 10)).format('MM/DD/YYYY')
     const paymentHasBeenMade = payment.date_paid != null
@@ -89,8 +88,7 @@ const PaymentTile = (props) => {
         history.push(`/clients/${client.id}/payments/${payment.id}/update`)
     }
     const handleRedirect = () => {
-        history.push(`/clients/${client.id}`)
-        localStorage.setItem('openPayment', payment.id)
+        history.push(`/clients/${client.id}?paymentId=${payment.id}`)
     }
     const handleAccordion = () => {
         setActiveAccordion(activeAccordion ? false : true)

--- a/src/components/PaymentsList.js
+++ b/src/components/PaymentsList.js
@@ -13,6 +13,10 @@ const PaymentsList = (props) => {
         project
     } = props
 
+    const activePayment = window.location.search
+        ? window.location.search.replace('?paymentId=', '')
+        : ''
+
     const renderPaymentTiles = (payments) => {
         return payments.map(p => {
             return (
@@ -22,7 +26,7 @@ const PaymentsList = (props) => {
                             payment={p}
                             client={p.client}
                             project={project}
-                            active={Number(localStorage.getItem('openPayment')) == p.id ? true : false}
+                            active={Number(activePayment) == p.id ? true : false}
                         />
                     </Box>
                 </Grid>

--- a/src/components/PaymentsList.js
+++ b/src/components/PaymentsList.js
@@ -22,6 +22,7 @@ const PaymentsList = (props) => {
                             payment={p}
                             client={p.client}
                             project={project}
+                            active={Number(localStorage.getItem('openPayment')) == p.id ? true : false}
                         />
                     </Box>
                 </Grid>

--- a/src/styles/PaymentTile.scss
+++ b/src/styles/PaymentTile.scss
@@ -23,6 +23,9 @@
     .project-name{
         text-transform: capitalize;
     }
+    .link:hover {
+        text-decoration: underline;
+    }
 }
 
 @media screen and (min-width: $sm) {


### PR DESCRIPTION
**Issue #645**
- [x] Make the text `$500 allocated to 2 other project(s)` clickable
- [x] After the text was clicked, redirect to the client page and expand the payment from the project that was clicked