### PR TITLE
Allow creation of payments without client Id

### DIFF
--- a/api/migrations/20221123062636-removeNotNullConstraintsFromPayments.js
+++ b/api/migrations/20221123062636-removeNotNullConstraintsFromPayments.js
@@ -1,0 +1,23 @@
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+          queryInterface.changeColumn('Payments', 'client_id', {
+              type: Sequelize.DataTypes.INTEGER,
+              allowNull: true
+          }, { transaction: t })
+      ])
+    })
+  },
+
+  async down (queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+          queryInterface.changeColumn('Payments', 'client_id', {
+              type: Sequelize.DataTypes.INTEGER,
+              allowNull: false
+          }, { transaction: t })
+        ])
+    })
+  }
+}

--- a/api/migrations/20221123064500-addCurrencyAndContributorToPayment.js
+++ b/api/migrations/20221123064500-addCurrencyAndContributorToPayment.js
@@ -5,7 +5,7 @@ module.exports = {
           queryInterface.addColumn('Payments', 'currency', {
             type: Sequelize.DataTypes.STRING
           }, { transaction: t }),
-          queryInterface.addColumn('Paymetns', 'contributor_id', {
+          queryInterface.addColumn('Payments', 'contributor_id', {
             type: Sequelize.DataTypes.INTEGER,
             allowNull: true,
             references: {

--- a/api/migrations/20221123064500-addCurrencyAndContributorToPayment.js
+++ b/api/migrations/20221123064500-addCurrencyAndContributorToPayment.js
@@ -1,0 +1,31 @@
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+          queryInterface.addColumn('Payments', 'currency', {
+            type: Sequelize.DataTypes.STRING
+          }, { transaction: t }),
+          queryInterface.addColumn('Paymetns', 'contributor_id', {
+            type: Sequelize.DataTypes.INTEGER,
+            allowNull: true,
+            references: {
+              model: 'Contributors',
+              id: 'key'
+            }
+          }, { transaction: t })
+        ])
+    })
+  },
+
+  async down (queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+          queryInterface.removeColumn('Payments', 'currency', {
+            type: Sequelize.DataTypes.STRING
+          }, { transaction: t }),
+          queryInterface.removeColumn('Payments', 'contributor_id', 
+            { transaction: t })
+        ])
+    })
+  }
+};

--- a/api/models/Payment.js
+++ b/api/models/Payment.js
@@ -33,7 +33,7 @@ module.exports = (sequelize) => {
         },
         client_id: { //FK
             type: DataTypes.INTEGER,
-            allowNull: false,
+            allowNull: true,
             references: {
                 model: 'Clients',
                 key: 'id',

--- a/api/models/Payment.js
+++ b/api/models/Payment.js
@@ -17,6 +17,10 @@ module.exports = (sequelize) => {
             type: DataTypes.INTEGER,
             allowNull: false
         },
+        currency: {
+            type: DataTypes.STRING,
+            allowNull: false
+        },
         external_uuid: {
             type: DataTypes.STRING,
             unique: true
@@ -37,6 +41,14 @@ module.exports = (sequelize) => {
             references: {
                 model: 'Clients',
                 key: 'id',
+            }
+        },
+        contributor_id: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+            references: {
+                model: 'Contributors',
+                key: 'id'
             }
         },
         project_id: {

--- a/api/modules/paymentManagement.js
+++ b/api/modules/paymentManagement.js
@@ -22,10 +22,14 @@ const paymentManagement = module.exports = (() => {
     }
 
     const processBitcoinInvoiceCreation = async (paymentId) => {
+        let paymentCurrency
+        let isClientCurrencyBtc = false
+        
         const payment = await db.models.Payment.findByPk(paymentId)
         const { 
             amount, 
             client_id, 
+            currency,
             date_paid, 
             external_uuid, 
             external_uuid_type 
@@ -33,18 +37,26 @@ const paymentManagement = module.exports = (() => {
 
         if (date_paid) throw new Error(`Payment has already been made`)
 
-        const client = await db.models.Client.findByPk(client_id)
-        const isClientCurrencyBtc = 
-            client.dataValues.currency === `BTC` ||
-            client.dataValues.currency === `SATS`
-        
+        if (client_id) {
+            const client = await db.models.Client.findByPk(client_id)
+            paymentCurrency = client.dataValues.currency
+            isClientCurrencyBtc = 
+            paymentCurrency === `BTC` ||
+            paymentCurrency === `SATS`
+        }
+
+        if (currency) {
+            isClientCurrencyBtc = currency === `BTC` || currency === `SATS`
+            paymentCurrency = currency
+        }
+
         if (!isClientCurrencyBtc) {
             throw new Error(`Client's currency is not Bitcoin`)
-        } 
-
+        }
+        
         const convertedAmount = Number(amount / 100)
 
-        const amountInSats = client.dataValues.currency === `BTC` 
+        const amountInSats = paymentCurrency === `BTC` 
             ? Number((convertedAmount * 100000000).toFixed(0)) // 100M sats = 1 BTC
             : convertedAmount
 

--- a/api/modules/paymentManagement.js
+++ b/api/modules/paymentManagement.js
@@ -22,8 +22,6 @@ const paymentManagement = module.exports = (() => {
     }
 
     const processBitcoinInvoiceCreation = async (paymentId) => {
-        let paymentCurrency
-        let isClientCurrencyBtc = false
         
         const payment = await db.models.Payment.findByPk(paymentId)
         const { 
@@ -37,18 +35,7 @@ const paymentManagement = module.exports = (() => {
 
         if (date_paid) throw new Error(`Payment has already been made`)
 
-        if (client_id) {
-            const client = await db.models.Client.findByPk(client_id)
-            paymentCurrency = client.dataValues.currency
-            isClientCurrencyBtc = 
-            paymentCurrency === `BTC` ||
-            paymentCurrency === `SATS`
-        }
-
-        if (currency) {
-            isClientCurrencyBtc = currency === `BTC` || currency === `SATS`
-            paymentCurrency = currency
-        }
+        const isClientCurrencyBtc = currency === `BTC` || currency === `SATS`
 
         if (!isClientCurrencyBtc) {
             throw new Error(`Client's currency is not Bitcoin`)
@@ -56,7 +43,7 @@ const paymentManagement = module.exports = (() => {
         
         const convertedAmount = Number(amount / 100)
 
-        const amountInSats = paymentCurrency === `BTC` 
+        const amountInSats = currency === `BTC` 
             ? Number((convertedAmount * 100000000).toFixed(0)) // 100M sats = 1 BTC
             : convertedAmount
 

--- a/api/schema/resolvers/PaymentResolver.js
+++ b/api/schema/resolvers/PaymentResolver.js
@@ -63,22 +63,26 @@ module.exports = {
                 date_incurred: createFields['date_incurred'],
                 date_paid: createFields['date_paid']
             })
-            const client = await models.Client.findOne({
-                where: {
-                    id: createFields['client_id']
-                }
-            })
-            // Check if the client has an associated Stripe account and if the currency is supported
-            // If it does, proceed to create the invoice on Stripe
-            if (client.external_uuid && STRIPE_SUPPORTED_CURRENCIES.includes(client.currency)) {
-                const stripeInvoice = await apiModules.paymentManagement.processStripeInvoiceWithPayment({
-                    amount: createFields['amount'],
-                    clientId: client.id,
-                    currency: client.currency,
-                    date_paid: createFields['date_paid']
+
+            if (createFields['client_id']) {
+                const client = createFields['client_id'] && await models.Client.findOne({
+                    where: {
+                        id: createFields['client_id']
+                    }
                 })
-                createFields['external_uuid'] = stripeInvoice.id
+                // Check if the client has an associated Stripe account and if the currency is supported
+                // If it does, proceed to create the invoice on Stripe
+                if (client.external_uuid && STRIPE_SUPPORTED_CURRENCIES.includes(client.currency)) {
+                    const stripeInvoice = await apiModules.paymentManagement.processStripeInvoiceWithPayment({
+                        amount: createFields['amount'],
+                        clientId: client.id,
+                        currency: client.currency,
+                        date_paid: createFields['date_paid']
+                    })
+                    createFields['external_uuid'] = stripeInvoice.id
+                }
             }
+            
             return models.Payment.create({
                 ...createFields
             })

--- a/api/schema/resolvers/PaymentResolver.js
+++ b/api/schema/resolvers/PaymentResolver.js
@@ -65,7 +65,7 @@ module.exports = {
             })
 
             if (createFields['client_id']) {
-                const client = createFields['client_id'] && await models.Client.findOne({
+                const client = await models.Client.findOne({
                     where: {
                         id: createFields['client_id']
                     }

--- a/api/schema/types/PaymentType.js
+++ b/api/schema/types/PaymentType.js
@@ -7,7 +7,9 @@ module.exports = gql`
         amount: Int!
         date_incurred: String!
         date_paid: String
-        client_id: Int!
+        client_id: Int
+        contributor_id: Int
+        currency: String
         totalAllocated: Int
         external_uuid: String
         external_uuid_type: String
@@ -16,10 +18,13 @@ module.exports = gql`
         isBitcoinInvoiceExpired: Boolean
         bitcoinCheckoutUrl: String
     }
+    
 
     input PaymentInput {
         amount: Int,
+        currency: String,
         client_id: Int,
+        contributor_id: Int,
         date_incurred: String,
         date_paid: String
     }

--- a/api/schema/types/PaymentType.js
+++ b/api/schema/types/PaymentType.js
@@ -22,7 +22,7 @@ module.exports = gql`
 
     input PaymentInput {
         amount: Int,
-        currency: String,
+        currency: String!,
         client_id: Int,
         contributor_id: Int,
         date_incurred: String,


### PR DESCRIPTION
- Eliminated the need of `client_id` to create Payments
- Added `currency` field to `Payment`
- Added `contributor_id` to `Payment`
- Enabled generation of BTC invoices without needing a Client