### PR TITLE
Payment without date paid error message

### DIFF
--- a/srcv2/pages/EditPaymentPage.js
+++ b/srcv2/pages/EditPaymentPage.js
@@ -44,7 +44,9 @@ const EditPaymentPage = (props) => {
             setPaymentAmount(payment.amount)
             setPaymentCurrency(payment.currency)
             setDateIncurred(moment(payment.date_incurred, 'x').format('YYYY-MM-DD'))
-            setDatePaid(moment(payment.date_paid, 'x').format('YYYY-MM-DD'))
+            setDatePaid(payment.date_paid 
+                ? moment(payment.date_paid, 'x').format('YYYY-MM-DD')
+                : null)
         }
     })
 


### PR DESCRIPTION
**Issue #777**

- [x] Validate if `datePaid` exists to assign it to null and not to an invalid date.

**Proof**
![image](https://user-images.githubusercontent.com/86666889/232164856-a3b4d914-7e2c-4a63-a6f8-5c089281bde8.png)
