### PR TITLE
Remove the dependency on currencyInformation for a project when sending bonuses

### DIFF
--- a/srcv2/components/SendBonusEqualy.js
+++ b/srcv2/components/SendBonusEqualy.js
@@ -19,11 +19,10 @@ const SendBonusEqualy = (props) => {
         setSelectedContributors(contributors)
     }, [selectedContributorsIdx])
 
-    const currencyInformation = project.expected_budget_currency
-        ? selectCurrencyInformation({
-            currency: project.expected_budget_currency
+    const currencyInformation = 
+        selectCurrencyInformation({
+            currency: 'USD'
         }) 
-        : null
 
     const selectContributor = (idx) => {
         if (selectedContributorsIdx.includes(idx)) {

--- a/srcv2/pages/AddPaymentPage.js
+++ b/srcv2/pages/AddPaymentPage.js
@@ -52,11 +52,12 @@ const AddPaymentPage = () => {
 
     const disabledPayment = !paymentAmount || !paymentIncurred
 
-    const currencyInformation = project.expected_budget_currency
-        ? selectCurrencyInformation({
+    const currencyInformation = 
+        selectCurrencyInformation({
             currency: project.expected_budget_currency
-        }) 
-        : null
+                ? project.expected_budget_currency
+                : 'USD' 
+        })
 
     const handleCreatePayment = async () => {
         if (disabledPayment) return


### PR DESCRIPTION
**Issue #837**

- [x] Fix currency dependency when sending bonuses
- [x] Fix currency dependency when creating a payment (another bug I found while testing)