### PR TITLE
Integrate project currency to Send Bonuses feature

### DIFF
--- a/srcv2/components/SendBonus.js
+++ b/srcv2/components/SendBonus.js
@@ -22,6 +22,7 @@ const SendBonus = (props) => {
     const [bonusPayments, setBonusPayments] = useState([])
     const [selectedBonusSplitType, setSelectedBonusSplitType] = useState(0)
     const [sentBonuses, setSentBonuses] = useState(0)
+    const [selectedCurrency, setSelectedCurrency] = useState('s ')
     
     const buttonText = ['Continue', 'Send bonuses', 'Finish']
 
@@ -34,7 +35,7 @@ const SendBonus = (props) => {
                     throw new Error('User does not have a wallet setup')
                 }
                 if (bp.contributor.wallet.invoice_macaroon != null || bp.contributor.wallet.onchain_address != null) {
-                    contributorsWithWallets.push({ contributor_id: bp.contributor.id, amount_to_pay: Math.round(bp.satsBonusAmount) })
+                    contributorsWithWallets.push({ contributor_id: bp.contributor.id, amount_to_pay: Math.round(selectedCurrency == 's ' ? bp.amount : bp.satsBonusAmount) })
                 }
             } catch (error) {
                 console.log('An error occurred: ' + error)
@@ -124,17 +125,21 @@ const SendBonus = (props) => {
                     setBonusPayments={setBonusPayments}
                     selectedBonusSplitType={selectedBonusSplitType}
                     setSelectedBonusSplitType={setSelectedBonusSplitType}
+                    selectedCurrency={selectedCurrency}
+                    setSelectedCurrency={setSelectedCurrency}
                 />
             }
             {screenIndex == 1 &&
                 <SendBonusConfirmation
                     bonusPayments={bonusPayments}
                     selectedBonusSplitType={selectedBonusSplitType}
+                    selectedCurrency={selectedCurrency}
                 />
             }
             {screenIndex == 2 && 
                 <SendBonusSuccessful
                     sentBonuses={sentBonuses}
+                    selectedCurrency={selectedCurrency}
                 />
             }
             <div className='grid absolute bottom-10 left-16 right-16 gap-2'>

--- a/srcv2/components/SendBonusAmount.js
+++ b/srcv2/components/SendBonusAmount.js
@@ -25,7 +25,9 @@ const SendBonusAmount = (props) => {
         bonusPayments,
         setBonusPayments,
         selectedBonusSplitType,
-        setSelectedBonusSplitType
+        setSelectedBonusSplitType,
+        selectedCurrency,
+        setSelectedCurrency
     } = props
 
     return (
@@ -60,6 +62,8 @@ const SendBonusAmount = (props) => {
                     setSelectedContributors={setSelectedContributors}
                     bonusAmount={bonusAmount}
                     setBonusAmount={setBonusAmount}
+                    selectedCurrency={selectedCurrency}
+                    setSelectedCurrency={setSelectedCurrency}
                 />
             ) : (
                 <SendBonusCustomize

--- a/srcv2/components/SendBonusConfirmation.js
+++ b/srcv2/components/SendBonusConfirmation.js
@@ -7,7 +7,8 @@ const SendBonusConfirmation = (props) => {
 
     const {
         bonusPayments,
-        selectedBonusSplitType
+        selectedBonusSplitType,
+        selectedCurrency
     } = props
 
     const renderSenders = () => {
@@ -21,11 +22,16 @@ const SendBonusConfirmation = (props) => {
                     </div>
                     <div className='grid grid-cols-1 text-right'>
                         <p className='font-bold'>
-                            {`${Intl.NumberFormat().format(Math.trunc(bp.satsBonusAmount))} SATS`}
+                            {selectedCurrency == 's '
+                                ? `${Intl.NumberFormat().format(Math.trunc(bp.amount))} SATS`
+                                : `${Intl.NumberFormat().format(Math.trunc(bp.satsBonusAmount))} SATS`
+                            }
                         </p>
-                        <p className='text-gray'>
-                            {`${Intl.NumberFormat('de-DE', { style: 'currency', currency: 'USD' }).format(Math.trunc(bp.amount))}`}
-                        </p>
+                        {selectedCurrency != 's ' &&
+                            <p className='text-gray'>
+                                {`${Intl.NumberFormat('de-DE', { style: 'currency', currency: 'USD' }).format(Math.trunc(bp.amount))}`}
+                            </p>
+                        }
                     </div>
                 </div>
             )
@@ -46,11 +52,16 @@ const SendBonusConfirmation = (props) => {
             {selectedBonusSplitType == 0 &&
                 <>
                     <p className='text-center text-4xl'>
-                        {`${Intl.NumberFormat().format(Math.trunc(bonusPayments[0].satsBonusAmount))} SATS`}
+                        {selectedCurrency == 's '
+                            ? `${Intl.NumberFormat().format(Math.trunc(bonusPayments[0].amount))} SATS`
+                            : `${Intl.NumberFormat().format(Math.trunc(bonusPayments[0].satsBonusAmount))} SATS`
+                        }
                     </p> 
-                    <p className='text-center text-md text-gray'>
-                        {`~ ${Intl.NumberFormat('de-DE', { style: 'currency', currency: 'USD' }).format(Math.trunc(bonusPayments[0].amount))}`}
-                    </p>
+                    {selectedCurrency != 's ' &&
+                        <p className='text-center text-md text-gray'>
+                            {`~ ${Intl.NumberFormat('de-DE', { style: 'currency', currency: 'USD' }).format(Math.trunc(bonusPayments[0].amount))}`}
+                        </p>
+                    }
                 </>
             }
             <p className='font-bold text-md text-gray'>

--- a/srcv2/components/SendBonusEqualy.js
+++ b/srcv2/components/SendBonusEqualy.js
@@ -9,20 +9,23 @@ const SendBonusEqualy = (props) => {
     const {
         setSelectedContributors,
         project,
-        setBonusAmount
+        setBonusAmount,
+        selectedCurrency,
+        setSelectedCurrency
     } = props
 
     const [selectedContributorsIdx, setSelectedContributorsIdx] = useState([])
+
+    const currencyInformation = selectCurrencyInformation({
+        currency: project.expected_budget_currency
+            ? project.expected_budget_currency
+            : 'SATS'
+    })
 
     useEffect(() => {
         const contributors = project.contributors.filter((c, idx) => selectedContributorsIdx.includes(idx))
         setSelectedContributors(contributors)
     }, [selectedContributorsIdx])
-
-    const currencyInformation = 
-        selectCurrencyInformation({
-            currency: 'USD'
-        }) 
 
     const selectContributor = (idx) => {
         if (selectedContributorsIdx.includes(idx)) {
@@ -73,18 +76,31 @@ const SendBonusEqualy = (props) => {
 
     return (
         <div className='SendBonusEqualy'>
-            <div className='mt-10'>
+            <div className='flex mt-10 items-center'>
                 <CurrencyTextField
                     fullWidth
                     label='Payment amount'
                     variant='outlined'
-                    currencySymbol={`${currencyInformation['symbol']}`}
+                    currencySymbol={`${selectedCurrency}`}
                     minimumValue='0'
                     outputFormat='string'
                     decimalCharacter={`${currencyInformation['decimal']}`}
                     digitGroupSeparator={`${currencyInformation['thousand']}`}
                     onChange={(event) => handleBonusAmountChange(event.target.value)}
                 />
+                <button 
+                    className='ml-3 bg-setlife text-black rounded-full p-2 flex items-center justify-center'
+                    type='button'
+                    onClick={() => setSelectedCurrency(selectedCurrency == 's '
+                        ? currencyInformation.symbol
+                        : 's ')
+                    }
+                >
+                    {selectedCurrency == currencyInformation.symbol
+                        ? <img className='w-7' src='https://project-trinary.s3.amazonaws.com/images/Satoshi+regular+black+2.png' alt='satoshi' />
+                        : <p className='w-6'>{currencyInformation.symbol}</p>
+                    } 
+                </button>
             </div>
             <div className='mt-10'>
                 <p className='font-bold text-md mb-4'>

--- a/srcv2/components/SendBonusSuccessful.js
+++ b/srcv2/components/SendBonusSuccessful.js
@@ -6,7 +6,8 @@ import {
 const SendBonusSuccessful = (props) => {
 
     const {
-        sentBonuses
+        sentBonuses,
+        selectedCurrency
     } = props
 
     const renderSuccessfulTransactions = (payments) => {
@@ -20,11 +21,16 @@ const SendBonusSuccessful = (props) => {
                     </div>
                     <div className='grid grid-cols-1 text-right'>
                         <p className='font-bold'>
-                            {`${Intl.NumberFormat().format(Math.trunc(bp.satsBonusAmount))} SATS`}
+                            {selectedCurrency == 's '
+                                ? `${Intl.NumberFormat().format(Math.trunc(bp.amount))} SATS`
+                                : `${Intl.NumberFormat().format(Math.trunc(bp.satsBonusAmount))} SATS`
+                            }
                         </p>
-                        <p className='text-gray'>
-                            {`${Intl.NumberFormat('de-DE', { style: 'currency', currency: 'USD' }).format(Math.trunc(bp.amount))}`}
-                        </p>
+                        {selectedCurrency != 's ' &&
+                            <p className='text-center text-md text-gray'>
+                                {`${Intl.NumberFormat('de-DE', { style: 'currency', currency: 'USD' }).format(Math.trunc(bp.amount))}`}
+                            </p>
+                        }
                     </div>
                 </div>
             )
@@ -42,10 +48,17 @@ const SendBonusSuccessful = (props) => {
                     </div>
                     <div className='grid grid-cols-1 text-right'>
                         <p className='font-bold'>
-                            {`${Intl.NumberFormat().format(Math.trunc(bp.satsBonusAmount))} SATS`}
+                            {selectedCurrency == 's '
+                                ? `${Intl.NumberFormat().format(Math.trunc(bp.amount))} SATS`
+                                : `${Intl.NumberFormat().format(Math.trunc(bp.satsBonusAmount))} SATS`
+                            }
                         </p>
                         <p className='text-gray'>
-                            {`${Intl.NumberFormat('de-DE', { style: 'currency', currency: 'USD' }).format(Math.trunc(bp.amount))}`}
+                            {selectedCurrency != 's ' &&
+                                <p className='text-center text-md text-gray'>
+                                    {`${Intl.NumberFormat('de-DE', { style: 'currency', currency: 'USD' }).format(Math.trunc(bp.amount))}`}
+                                </p>
+                            }
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
**Issue #838**

- [x] Use the project currency to provide a real-time conversion from sats to fiat
- [x] allow the user to type in either SATS or the fiat currency configured for the project
- [x] if the project currency is already SATS then no need to provide conversion

**Proof**
_Using sats_
![image](https://github.com/setlife-network/trinary/assets/86666889/05c198de-4ff2-4091-ad12-f355b398ac59)
![image](https://github.com/setlife-network/trinary/assets/86666889/9e2a39f4-c4ba-4594-a55d-01e85ee6f349)
![image](https://github.com/setlife-network/trinary/assets/86666889/d3c56dd7-30ca-4169-889e-0831cf49d8d5)

_Using another currency_
![image](https://github.com/setlife-network/trinary/assets/86666889/ffc3ac3c-1c84-433c-853d-787f6e38ce3c)
![image](https://github.com/setlife-network/trinary/assets/86666889/70582d53-b2e9-4083-84b8-d244db95e909)
![image](https://github.com/setlife-network/trinary/assets/86666889/e35bcc68-d67c-42b0-8f69-62922ad493d3)
